### PR TITLE
Fix WOF source name

### DIFF
--- a/batch-setup/make_rawr_tiles.py
+++ b/batch-setup/make_rawr_tiles.py
@@ -139,7 +139,7 @@ def any_jobs_with_status(batch, job_queue, status):
     return len(response['jobSummaryList']) > 0
 
 
-def wait_for_jobs_to_finish(job_queue, wait_time=60):
+def wait_for_jobs_to_finish(job_queue, wait_time=300):
     """
     Wait until there are no jobs in the queue with a non-finished status.
 
@@ -160,7 +160,7 @@ def wait_for_jobs_to_finish(job_queue, wait_time=60):
                        'RUNNING'):
             if any_jobs_with_status(batch, job_queue, status):
                 jobs_remaining = True
-                print("Still have jobs left in queue.")
+                print("[%s] Still have jobs left in queue." % (time.ctime()))
                 time.sleep(wait_time)
                 break
     print("All jobs finished (either SUCCEEDED or FAILED)")

--- a/docker/meta-batch/config.yaml
+++ b/docker/meta-batch/config.yaml
@@ -37,7 +37,7 @@ rawr:
       planet_osm_polygon: *osm
       planet_osm_ways: *osm
       planet_osm_rels: *osm
-      wof_neighbourhood: { name: wof, value: whosonfirst.mapzen.com }
+      wof_neighbourhood: { name: wof, value: whosonfirst.org }
       water_polygons: &osmdata { name: shp, value: openstreetmapdata.com }
       land_polygons: *osmdata
       ne_10m_urban_areas: { name: ne, value: naturalearthdata.com }

--- a/docker/rawr-batch/config.yaml
+++ b/docker/rawr-batch/config.yaml
@@ -16,7 +16,7 @@ rawr:
       planet_osm_polygon: *osm
       planet_osm_ways: *osm
       planet_osm_rels: *osm
-      wof_neighbourhood: { name: wof, value: whosonfirst.mapzen.com }
+      wof_neighbourhood: { name: wof, value: whosonfirst.org }
       water_polygons: &osmdata { name: shp, value: openstreetmapdata.com }
       land_polygons: *osmdata
       ne_10m_urban_areas: { name: ne, value: naturalearthdata.com }


### PR DESCRIPTION
Ooops, looks like the source name here was wrong (still `whosonfirst.mapzen.com`), and was causing exceptions to be thrown.

Also, a couple of small improvements:

* Don't try to enqueue empty lists of tiles. Count the low and high lists separately.
* Print info about the time while waiting for jobs to finish.
