### PR TITLE
Config for July 2018

### DIFF
--- a/batch-setup/docker.py
+++ b/batch-setup/docker.py
@@ -33,13 +33,16 @@ def build_image(path, registry_url):
 
 
 def build_and_upload_images(repo_uris):
-    # TODO: this is pretty horrible. perhaps we can specify a git URL + tag to
-    # download and use?
-    for repo in ('vector-datasource', 'tilequeue', 'raw_tiles'):
-        if not os.path.isdir("../../%s" % repo):
-            raise RuntimeError("You must check out the %s repository "
-                               "alongside tzops to build Docker images."
-                               % repo)
+    script_dir = os.path.dirname(os.path.realpath(__file__))
+    # change directory to be the same as the script, so that the relative paths work.
+    with change_dir(script_dir):
+        # TODO: this is pretty horrible. perhaps we can specify a git URL + tag to
+        # download and use?
+        for repo in ('vector-datasource', 'tilequeue', 'raw_tiles'):
+            if not os.path.isdir("../../%s" % repo):
+                raise RuntimeError("You must check out the %s repository "
+                                   "alongside tzops to build Docker images."
+                                   % repo)
 
-    for path, registry_url in repo_uris.items():
-        build_image(path, registry_url)
+        for path, registry_url in repo_uris.items():
+            build_image(path, registry_url)

--- a/batch-setup/make_tiles.py
+++ b/batch-setup/make_tiles.py
@@ -120,5 +120,5 @@ for name in ('rawr-batch', 'meta-batch', 'meta-low-zoom-batch',
 # functionality already in various tools we use. this seemed a good place to
 # have a "breakpoint" where we'd "lock in" and not re-run the previous steps.
 print("RUN THIS NEXT>> python make_rawr_tiles.py "
-      "--config rawr-enqueue-batch.config.yaml %r %r"
+      "--config enqueue-rawr-batch.config.yaml %r %r"
       % (buckets.rawr, date_prefix))

--- a/batch-setup/teardown.py
+++ b/batch-setup/teardown.py
@@ -1,0 +1,137 @@
+from rds import ensure_dbs
+from make_rawr_tiles import wait_for_jobs_to_finish
+from batch import terminate_all_jobs
+import boto3
+
+
+def delete_all_job_definitions(batch, planet_date):
+    job_definitions = []
+    date_suffix = planet_date.strftime('-%y%m%d')
+
+    print("Listing job definitions to delete.")
+    next_token = None
+    response = batch.describe_job_definitions()
+    while True:
+        for jobdef in response.get('jobDefinitions', []):
+            name = jobdef['jobDefinitionName']
+            revision = jobdef['revision']
+            if name.endswith(date_suffix):
+                job_definitions.append('%s:%d' % (name, revision))
+        next_token = response.get('nextToken')
+        if next_token is None:
+            break
+        response = batch.describe_job_definitions(nextToken=next_token)
+
+    for def_name in job_definitions:
+        print("Deleting job definition %r" % (def_name,))
+        batch.deregister_job_definition(jobDefinition=def_name)
+
+
+def delete_job_queue(batch, job_queue, terminate):
+    if terminate:
+        # terminate any jobs which are running
+        terminate_all_jobs(job_queue, 'Tearing down the stack')
+
+    # always need to wait for jobs, even if we have terminated them we need to
+    # wait for the termination to complete.
+    wait_for_jobs_to_finish(job_queue)
+
+    # disable the job queue
+    print("Disabling job queue %r" % (job_queue,))
+    batch.update_job_queue(jobQueue=job_queue, state='DISABLED')
+
+    print("Waiting for job queue to disable.")
+    while True:
+        response = batch.describe_job_queues(jobQueues=[job_queue])
+        assert len(response['jobQueues']) == 1
+        q = response['jobQueues'][0]
+        state = q['state']
+        status = q['status']
+        if status == 'UPDATING':
+            print("Queue %r is updating, waiting..." % (job_queue,))
+
+        elif state == 'DISABLED':
+            break
+
+        else:
+            raise RuntimeError('Expected status=UPDATING or state=DISABLED, '
+                               'but status=%r and state=%r' % (status, state))
+
+        # wait a little bit before checking again.
+        sleep(15)
+
+    # delete the job queue
+    print("Deleting job queue %r" % (job_queue,))
+    batch.delete_job_queue(jobQueue=job_queue)
+
+
+if __name__ == '__main__':
+    import argparse
+    from datetime import datetime
+    import os
+    from time import sleep
+
+    parser = argparse.ArgumentParser("Tear down a stack")
+    parser.add_argument('date', help='Planet date, YYMMDD')
+    parser.add_argument('--terminate', action='store_true', help='Terminate '
+                        'jobs, rather than waiting for them to finish.')
+    parser.add_argument('--job-queue', help='Job queue name, default '
+                        'job-queue-YYMMDD with planet date.')
+    parser.add_argument('--compute-env', help='Compute environment name, '
+                        'default compute-env-YYMMDD with planet date.')
+    parser.add_argument('--region', help='AWS region. Default taken from '
+                        'the AWS_DEFAULT_REGION environment variable.')
+
+    args = parser.parse_args()
+    planet_date = datetime.strptime(args.date, '%y%m%d')
+    job_queue = args.job_queue or planet_date.strftime('job-queue-%y%m%d')
+    compute_env = args.compute_env or planet_date.strftime(
+        'compute-env-%y%m%d')
+    region = args.region or os.environ.get('AWS_DEFAULT_REGION')
+
+    if region is None:
+        import sys
+        print "ERROR: Need environment variable AWS_DEFAULT_REGION to be set."
+        sys.exit(1)
+
+    batch = boto3.client('batch')
+
+    response = batch.describe_job_queues(jobQueues=[job_queue])
+    if len(response['jobQueues']) > 0:
+        delete_job_queue(batch, job_queue, args.terminate)
+
+    # delete the job definitions
+    delete_all_job_definitions(batch, planet_date)
+
+    # disable the compute environment
+    print("Disabling compute environment %r" % (compute_env,))
+    batch.update_compute_environment(
+        computeEnvironment=compute_env, state='DISABLED')
+
+    print("Waiting for compute environment to disable.")
+    while True:
+        response = batch.describe_compute_environments(
+            computeEnvironments=[compute_env])
+        assert len(response['computeEnvironments']) == 1
+        env = response['computeEnvironments'][0]
+        state = env['state']
+        status = env['status']
+        if status == 'UPDATING':
+            print("Environment %r is updating, waiting..." % (compute_env,))
+
+        elif state == 'DISABLED':
+            break
+
+        else:
+            raise RuntimeError('Expected status=UPDATING or state=DISABLED, '
+                               'but status=%r and state=%r' % (status, state))
+
+        # wait a little bit before checking again.
+        sleep(15)
+
+    # delete the compute environment
+    print("Deleting compute environment %r" % (compute_env,))
+    batch.delete_compute_environment(computeEnvironment=compute_env)
+
+    # shutdown all database replicas
+    ensure_dbs(planet_date, 0)

--- a/docker/meta-batch/config.yaml
+++ b/docker/meta-batch/config.yaml
@@ -25,8 +25,9 @@ process:
       path: /usr/src/vector-datasource/yaml
 logging: {config: /etc/tilequeue/logging.conf}
 metatile:
-  size: 4
+  size: 8
   start-zoom: 0
+  tile-sizes: [512]
 rawr:
   group-zoom: 10
   source:

--- a/docker/meta-batch/config.yaml
+++ b/docker/meta-batch/config.yaml
@@ -41,6 +41,8 @@ rawr:
       water_polygons: &osmdata { name: shp, value: openstreetmapdata.com }
       land_polygons: *osmdata
       ne_10m_urban_areas: { name: ne, value: naturalearthdata.com }
+      admin_areas: *osm
+      buffered_land: { name: shp, value: tilezen.org }
     s3:
       bucket: ...
       region: ...

--- a/docker/meta-low-zoom-batch/config.yaml
+++ b/docker/meta-low-zoom-batch/config.yaml
@@ -23,8 +23,9 @@ process:
       path: /usr/src/vector-datasource/yaml
 logging: {config: /etc/tilequeue/logging.conf}
 metatile:
-  size: 4
+  size: 8
   start-zoom: 0
+  tile-sizes: [512]
 rawr:
   group-zoom: 10
 use-rawr-tiles: false

--- a/docker/rawr-batch/config.yaml
+++ b/docker/rawr-batch/config.yaml
@@ -1,7 +1,7 @@
 logging: {config: /etc/tilequeue/logging.conf}
 rawr:
   group-zoom: 10
-  sources: [osm, wof, water_polygons, land_polygons, ne_10m_urban_areas]
+  sources: [osm, wof, water_polygons, land_polygons, ne_10m_urban_areas, admin_areas, buffered_land]
   postgresql:
     host: ...
     port: 5432
@@ -20,6 +20,8 @@ rawr:
       water_polygons: &osmdata { name: shp, value: openstreetmapdata.com }
       land_polygons: *osmdata
       ne_10m_urban_areas: { name: ne, value: naturalearthdata.com }
+      admin_areas: *osm
+      buffered_land: { name: shp, value: tilezen.org }
   sink:
     type: s3
     s3:

--- a/import/import.py
+++ b/import/import.py
@@ -17,6 +17,9 @@ parser.add_argument('iam-instance-profile', help="IAM instance profile to "
                     "access to the S3 bucket for storing flat nodes.")
 parser.add_argument('database-password', help="The 'master user password' "
                     "to use when setting up the RDS database.")
+parser.add_argument('--vector-datasource-version', default='master',
+                    help='Version (git branch, ref or commit) to use when '
+                    'setting up the database.')
 
 args = parser.parse_args()
 
@@ -32,6 +35,6 @@ else:
 db = database.ensure_database(planet_date, getattr(args, 'database-password'))
 
 osm2pgsql.ensure_import(planet_date, db, getattr(args, 'iam-instance-profile'),
-                        args.bucket, args.region)
+                        args.bucket, args.region, args.vector_datasource_version)
 
 database.take_snapshot_and_shutdown(db, planet_date)

--- a/import/import_planet.sh
+++ b/import/import_planet.sh
@@ -11,6 +11,7 @@ FLAT_NODES_BUCKET='%(flat_nodes_bucket)s'
 FLAT_NODES_KEY='%(flat_nodes_key)s'
 export AWS_DEFAULT_REGION='%(aws_region)s'
 export OSM2PGSQL='/usr/bin/osm2pgsql'
+VECTOR_DATASOURCE_VERSION='%(vector_datasource_version)s'
 
 # we don't want the STATUS file moving around while we change working directories, especially if
 # we have to report a failure.
@@ -96,6 +97,7 @@ echo "checking planet file MD5" > $STATUS
 if [[ ! -d vector-datasource ]]; then
     echo "checking out vector-datasource" > $STATUS
     git clone https://github.com/tilezen/vector-datasource.git
+    (cd vector-datasource && git checkout "${VECTOR_DATASOURCE_VERSION}")
 fi
 
 # set up database - it needs extensions adding prior to osm2pgsql run

--- a/import/osm2pgsql.py
+++ b/import/osm2pgsql.py
@@ -394,7 +394,8 @@ def shutdown_and_cleanup(ec2, import_instance_id, planet_date):
             raise
 
 
-def ensure_import(planet_date, db, iam_instance_profile, bucket, aws_region):
+def ensure_import(planet_date, db, iam_instance_profile, bucket, aws_region,
+                  vector_datasource_version='master'):
     ec2 = boto3.client('ec2')
 
     # is there already an import instance running?
@@ -471,6 +472,7 @@ def ensure_import(planet_date, db, iam_instance_profile, bucket, aws_region):
             flat_nodes_bucket=bucket,
             flat_nodes_key=flat_nodes_key(planet_date),
             aws_region=aws_region,
+            vector_datasource_version=vector_datasource_version,
         )
 
     shutdown_and_cleanup(ec2, import_instance_id, planet_date)


### PR DESCRIPTION
Apologies for the random grab bag of stuff, but this had been building up in my local copy and I thought it should be merged in.

This includes:

* Some minor fixes and tweaks to make it easier to use; fixing a comment, allowing a specified version of `vector-datasource` for the import, making the scripts not `$PWD` dependent.
* Added admin areas and buffered land tables to RAWR tiles configs.
* Added a teardown script to clean up an environment after the build is complete.
* Larger metatile size (8x8) and only generate 512px tiles. It's possible that other people will want to make different choices, but our config is already pretty opinionated, so I figured it's better it tracks our opinion than drifts to be nobody's opinion.
