### PR TITLE
Increase rds snapshot wait time

### DIFF
--- a/import/database.py
+++ b/import/database.py
@@ -140,8 +140,8 @@ def take_snapshot_and_shutdown(db, planet_date):
     waiter.wait(
         DBSnapshotIdentifier=instance_id,
         WaiterConfig=dict(
-            Delay=30,
-            MaxAttempts=60,
+            Delay=60,
+            MaxAttempts=240,
         ),
     )
 


### PR DESCRIPTION
The waiter timed out for me, even though the snapshot succeeded. 4 hours might be way too much, but it seems safer to be way over than a little under.