### PR TITLE
Add a few scripts that I've found useful.

### DIFF
--- a/utils/count_jobs.py
+++ b/utils/count_jobs.py
@@ -1,0 +1,54 @@
+import boto3
+import argparse
+import datetime
+import time
+
+
+def count_jobs(batch, job_queue):
+    total = 0
+    message = ""
+
+    for status in ('SUBMITTED', 'PENDING', 'RUNNABLE', 'STARTING',
+                   'RUNNING'):
+        response = batch.list_jobs(
+            jobQueue=job_queue,
+            jobStatus=status,
+        )
+        status_sum = 0
+        while response.get('jobSummaryList'):
+            status_sum += len(response['jobSummaryList'])
+            next_token = response.get('nextToken')
+            if not next_token:
+                break
+            response = batch.list_jobs(
+                jobQueue=job_queue,
+                jobStatus=status,
+                nextToken=next_token,
+            )
+        if message:
+            message += ", "
+        message += "%6d %s" % (status_sum, status)
+        total += status_sum
+
+    return "%6d TOTAL (%s)" % (total, message)
+
+
+parser = argparse.ArgumentParser(description="""
+Count the jobs in each status in the job queue. This gives you the true count
+of all the jobs, rather than the "1000+" that gets shown in the Batch console.
+""")
+parser.add_argument("date", help="Date prefix to use, YYMMDD.")
+args = parser.parse_args()
+
+job_queue = 'job-queue-%s' % (args.date,)
+batch = boto3.client('batch')
+
+interval = 60 * 5
+next_time = time.time()
+while True:
+    now = datetime.datetime.now()
+    msg = count_jobs(batch, job_queue)
+    print("[%s] %s" % (now.strftime("%Y-%m-%d %H:%M:%S"), msg))
+
+    next_time += interval
+    time.sleep(next_time - time.time())

--- a/utils/list-batch-logs.py
+++ b/utils/list-batch-logs.py
@@ -1,0 +1,85 @@
+import boto3
+import json
+import argparse
+
+
+def list_job_ids(batch, **kwargs):
+    next_token = None
+    job_ids = []
+    while True:
+        args = kwargs.copy()
+        if next_token:
+            args['nextToken'] = next_token
+        response = batch.list_jobs(**args)
+        for job_summary in response['jobSummaryList']:
+            if 'missing-meta-tiles' not in job_summary['jobName']:
+                job_ids.append(job_summary['jobId'])
+        next_token = response.get('nextToken')
+        if next_token is None:
+            break
+
+    return job_ids
+
+
+def print_failures(cwlogs, log_stream_name):
+    log_group_name = '/aws/batch/job'
+    next_token = None
+    while True:
+        args = dict(
+            logGroupName=log_group_name,
+            logStreamName=log_stream_name,
+            startFromHead=False,
+        )
+        if next_token:
+            args['nextToken'] = next_token
+        response = cwlogs.get_log_events(**args)
+        for event in response['events']:
+            msg = event['message']
+            if len(msg) > 10 and msg[25] == '{' and msg.endswith('}'):
+                msg = json.loads(msg[25:])
+                if msg.get('type') == 'error':
+                    coord = msg['coord']
+                    coord_str = "%d/%d/%d" % (coord['z'], coord['x'],
+                                              coord['y'])
+                    print("%15s: %s" % (coord_str, msg['exception']))
+                    trace = msg.get('stacktrace')
+                    if trace:
+                        print("    " + trace.replace("|", "\n    "))
+
+        new_token = response.get('nextForwardToken')
+        if new_token is None or new_token == next_token:
+            break
+        next_token = new_token
+
+
+parser = argparse.ArgumentParser(description="""
+Prints errors from CloudWatch Logs from the most recent successful jobs.
+
+A single TPS job typically renders many tiles, some of which might fail.
+Because we don't want to stop the whole job because of a single failure, the
+job will succeed even when some individual tiles fail. This makes pulling the
+failures out of the rest of the logs more difficult.
+
+That's where this tool comes in: Point it at a job queue and it'll list out
+all the jobs which had failed tiles, and the stacktrace of the failure.
+
+Batch only retains jobs for about 24h, so you'll want to run this pretty soon
+after all the jobs finish - or even several times during the run!
+""")
+parser.add_argument('job_queue', help='Job queue to list jobs from.')
+args = parser.parse_args()
+
+batch = boto3.client('batch')
+cwlogs = boto3.client('logs')
+
+job_ids = list_job_ids(batch, jobQueue=args.job_queue, jobStatus='SUCCEEDED')
+num_chunks = len(job_ids) / 100
+for i in xrange(0, num_chunks + 1):
+    chunk = job_ids[(100 * i):(100 * (i+1))]
+    response = batch.describe_jobs(jobs=chunk)
+    for job in response['jobs']:
+        name = job['jobName']
+        last_attempt = job['attempts'][-1]
+        log_stream_name = last_attempt['container']['logStreamName']
+        print("=== %s ===\n" % (name,))
+        print_failures(cwlogs, log_stream_name)

--- a/utils/meta-high-job-times.py
+++ b/utils/meta-high-job-times.py
@@ -1,0 +1,40 @@
+import boto3
+import argparse
+
+
+parser = argparse.ArgumentParser(description="""
+Print the job coordinate and amount of time in milliseconds the job took to
+complete. This can help identify long-running jobs (which finished in the
+past 24h) and therefore help to identify why they take so long.
+""")
+parser.add_argument('date', help='Date prefix to use, YYMMDD')
+args = parser.parse_args()
+
+job_queue = 'job-queue-' + args.date
+prefix = 'meta-batch-%s-' % (args.date,)
+batch = boto3.client('batch')
+
+next_token = None
+while True:
+    kwargs = dict(
+        jobQueue=job_queue,
+        jobStatus='SUCCEEDED',
+    )
+    if next_token:
+        kwargs['nextToken'] = next_token
+    response = batch.list_jobs(**kwargs)
+
+    for job in response['jobSummaryList']:
+        array_props = job.get('arrayProperties')
+        if array_props:
+            continue
+
+        duration = job['stoppedAt'] - job['startedAt']
+        name = job['jobName']
+        if name.startswith(prefix):
+            coord_str = name[len(prefix):].replace('-', '/')
+            print("%s\t%d" % (coord_str, duration))
+
+    next_token = response.get('nextToken')
+    if not next_token:
+        break


### PR DESCRIPTION
These are:

* `count_jobs.py` - Gives the true count of jobs in a Batch job queue by status, without the `1000+` that the Batch web console gives. Useful when the difference between 1,001 and 10,000 is meaningful.
* `list-batch-logs.py` - Lists the stacktraces found in the logs of all the Batch jobs completed in the past 24h. Can cut down the amount of time it takes to figure out why certain tiles are missing.
* `meta-high-job-times.py` - Lists the time taken by each high-zoom (i.e: RAWR-based) job in the past 24h. Can be useful for figuring out which jobs to focus optimisation efforts on.
