### PR TITLE
Update Docker images to install coanacatl.

### DIFF
--- a/docker/meta-batch/Dockerfile
+++ b/docker/meta-batch/Dockerfile
@@ -1,7 +1,7 @@
 FROM python:2
 
 RUN apt-get -y update \
- && apt-get -y install libgeos-dev \
+ && apt-get -y install libgeos-dev libboost-python-dev \
  && rm -rf /var/lib/apt/lists/*
 
 COPY raw_tiles /usr/src/raw_tiles

--- a/docker/meta-batch/config.yaml
+++ b/docker/meta-batch/config.yaml
@@ -19,7 +19,7 @@ process:
   query-config: /usr/src/vector-datasource/queries.yaml
   template-path: /usr/src/vector-datasource/queries
   reload-templates: false
-  formats: [mvt]
+  formats: [coanacatl]
   yaml:
     # TODO should be using the callable config here instead
     type: parse

--- a/docker/meta-batch/requirements.txt
+++ b/docker/meta-batch/requirements.txt
@@ -27,4 +27,4 @@ zope.dottedname==4.2
 edtf==2.6.0
 mapbox-vector-tile==1.2.0
 boto3==1.7.10
-git+https://github.com/tilezen/coanacatl@zerebubuth/support-geos-3.4.x#egg=coanacatl
+git+https://github.com/tilezen/coanacatl@v0.1.0#egg=coanacatl

--- a/docker/meta-batch/requirements.txt
+++ b/docker/meta-batch/requirements.txt
@@ -27,3 +27,4 @@ zope.dottedname==4.2
 edtf==2.6.0
 mapbox-vector-tile==1.2.0
 boto3==1.7.10
+git+https://github.com/tilezen/coanacatl@zerebubuth/support-geos-3.4.x#egg=coanacatl

--- a/docker/meta-low-zoom-batch/Dockerfile
+++ b/docker/meta-low-zoom-batch/Dockerfile
@@ -1,7 +1,7 @@
 FROM python:2
 
 RUN apt-get -y update \
- && apt-get -y install libgeos-dev \
+ && apt-get -y install libgeos-dev libboost-python-dev \
  && rm -rf /var/lib/apt/lists/*
 
 COPY raw_tiles /usr/src/raw_tiles

--- a/docker/meta-low-zoom-batch/config.yaml
+++ b/docker/meta-low-zoom-batch/config.yaml
@@ -17,7 +17,7 @@ process:
   query-config: /usr/src/vector-datasource/queries.yaml
   template-path: /usr/src/vector-datasource/queries
   reload-templates: false
-  formats: [mvt]
+  formats: [coanacatl]
   yaml:
     # TODO should be using the callable config here instead
     type: parse

--- a/docker/meta-low-zoom-batch/requirements.txt
+++ b/docker/meta-low-zoom-batch/requirements.txt
@@ -27,4 +27,4 @@ zope.dottedname==4.2
 edtf==2.6.0
 mapbox-vector-tile==1.2.0
 boto3==1.7.10
-git+https://github.com/tilezen/coanacatl@zerebubuth/support-geos-3.4.x#egg=coanacatl
+git+https://github.com/tilezen/coanacatl@v0.1.0#egg=coanacatl

--- a/docker/meta-low-zoom-batch/requirements.txt
+++ b/docker/meta-low-zoom-batch/requirements.txt
@@ -27,3 +27,4 @@ zope.dottedname==4.2
 edtf==2.6.0
 mapbox-vector-tile==1.2.0
 boto3==1.7.10
+git+https://github.com/tilezen/coanacatl@zerebubuth/support-geos-3.4.x#egg=coanacatl


### PR DESCRIPTION
Add configuration to go along with https://github.com/tilezen/tilequeue/pull/350 - this switches the driver used in tileops from `mvt` to `coanacatl` (still writes MVT, just via [Wagyu](https://github.com/mapbox/wagyu) rather than [mapbox-vector-tile](https://github.com/tilezen/mapbox-vector-tile)). 

 **Reminder: Do not merge until https://github.com/tilezen/coanacatl/pull/1 is merged and the `requirements.txt` Git branches can be reset back to `master` - or a release tag.**
