### PR TITLE
Make metatile size and max zoom configurable.

### DIFF
--- a/batch-setup/cron.py
+++ b/batch-setup/cron.py
@@ -491,6 +491,8 @@ if __name__ == '__main__':
     parser.add_argument('--tileops-version', default='master',
                         help='Version (git hash, tag or branch) of the '
                         'tileops software to use on the TPS instance.')
+    parser.add_argument('--metatile-size', default=8, type=int,
+                        help='Metatile size (in 256px tiles).')
 
     args = parser.parse_args()
     planet_date = datetime.strptime(args.date, '%y%m%d')
@@ -563,6 +565,7 @@ if __name__ == '__main__':
         tilequeue_version=args.tilequeue_version,
         vector_datasource_version=args.vector_datasource_version,
         tileops_version=args.tileops_version,
+        metatile_size=args.metatile_size,
     )
 
     script_dir = os.path.dirname(os.path.realpath(__file__))

--- a/batch-setup/provision.sh
+++ b/batch-setup/provision.sh
@@ -48,6 +48,8 @@ export DATE_PREFIX='%(planet_date)s'
 export RAW_TILES_VERSION='%(raw_tiles_version)s'
 export TILEQUEUE_VERSION='%(tilequeue_version)s'
 export VECTOR_DATASOURCE_VERSION='%(vector_datasource_version)s'
+
+export METATILE_SIZE='%(metatile_size)s'
 eof
 
 mkdir /tmp/awslogs
@@ -81,7 +83,7 @@ python -u /usr/local/src/tileops/batch-setup/make_tiles.py --num-db-replicas 10 
 python -u /usr/local/src/tileops/batch-setup/make_rawr_tiles.py --config enqueue-rawr-batch.config.yaml --key-format-type hash-prefix \
        \$RAWR_BUCKET \$DATE_PREFIX \$MISSING_BUCKET
 python -u /usr/local/src/tileops/batch-setup/make_meta_tiles.py --date-prefix \$DATE_PREFIX --missing-bucket \$MISSING_BUCKET \
-       --key-format-type hash-prefix \$RAWR_BUCKET \$META_BUCKET \$DATE_PREFIX
+       --key-format-type hash-prefix --metatile_size \$METATILE_SIZE \$RAWR_BUCKET \$META_BUCKET \$DATE_PREFIX
 EOF
 chmod +x /usr/local/bin/run.sh
 


### PR DESCRIPTION
Looks like the default max zoom to check for missing tiles is 14, which means that it'll think that _all_ zoom 14 tiles are missing if the metatile size is larger than 4x4. Instead, the max zoom to check should be based on the metatile size, which has been added as an argument.