### PR TITLE
Fix bugs in "skip import if DB snapshot exists"

### DIFF
--- a/batch-setup/cron.py
+++ b/batch-setup/cron.py
@@ -424,6 +424,18 @@ def create_security_group_allowing_this_ip(ec2):
     return sg_id
 
 
+def is_power_of_two(x):
+    """
+    Returns true if x is a power of two, false otherwise.
+    """
+
+    from math import log
+    if x <= 0:
+        return False
+    log2 = int(log(x, 2))
+    return x == 2 ** log2
+
+
 if __name__ == '__main__':
     from datetime import datetime
     import argparse
@@ -502,6 +514,12 @@ if __name__ == '__main__':
         import sys
         print "ERROR: Need environment variable AWS_DEFAULT_REGION to be set."
         sys.exit(1)
+
+    # checking that metatile size has a valid value, and it's in a sensible
+    # range
+    assert is_power_of_two(args.metatile_size)
+    assert args.metatile_size > 0
+    assert args.metatile_size < 100
 
     profile_name = args.profile_name
     if profile_name is None:

--- a/batch-setup/make_meta_tiles.py
+++ b/batch-setup/make_meta_tiles.py
@@ -239,6 +239,9 @@ if __name__ == '__main__':
         print "ERROR: Need environment variable AWS_DEFAULT_REGION to be set."
         sys.exit(1)
 
+    # check that metatile_size is within a sensible range
+    assert args.metatile_size > 0
+    assert args.metatile_size < 100
     metatile_max_zoom = 16 - metatile_zoom_from_size(args.metatile_size)
     tile_finder = MissingTileFinder(
         buckets.missing, buckets.meta, date_prefix, region,

--- a/batch-setup/make_meta_tiles.py
+++ b/batch-setup/make_meta_tiles.py
@@ -98,7 +98,7 @@ class MissingTileFinder(object):
             '-src-date-prefix', self.date_prefix,
             '-region', self.region,
             '-key-format-type', self.key_format_type,
-            '-max-zoom', self.max_zoom,
+            '-max-zoom', str(self.max_zoom),
         )
 
         print("Waiting for jobs to finish...")

--- a/batch-setup/make_meta_tiles.py
+++ b/batch-setup/make_meta_tiles.py
@@ -98,7 +98,6 @@ class MissingTileFinder(object):
             '-src-date-prefix', self.date_prefix,
             '-region', self.region,
             '-key-format-type', self.key_format_type,
-            '-max-zoom', str(self.max_zoom),
         )
 
         print("Waiting for jobs to finish...")
@@ -116,6 +115,7 @@ class MissingTileFinder(object):
                '-region', self.region,
                '-present=%r' % (bool(present),),
                '-compress-output=%r' % (bool(compress),),
+               '-max-zoom', str(self.max_zoom),
                stdout=filename)
 
     @contextmanager

--- a/batch-setup/make_rawr_tiles.py
+++ b/batch-setup/make_rawr_tiles.py
@@ -38,7 +38,7 @@ def missing_tiles(missing_bucket, rawr_bucket, date_prefix, region,
 
     finder = MissingTileFinder(
         missing_bucket, rawr_bucket, date_prefix, region, key_format_type,
-        config)
+        config, zoom)
 
     with finder.present_tiles() as present_file:
         with open(present_file) as fh:

--- a/batch-setup/provision.sh
+++ b/batch-setup/provision.sh
@@ -49,7 +49,7 @@ export RAW_TILES_VERSION='%(raw_tiles_version)s'
 export TILEQUEUE_VERSION='%(tilequeue_version)s'
 export VECTOR_DATASOURCE_VERSION='%(vector_datasource_version)s'
 
-export METATILE_SIZE='%(metatile_size)s'
+export METATILE_SIZE='%(metatile_size)d'
 eof
 
 mkdir /tmp/awslogs
@@ -74,7 +74,10 @@ cat > /usr/local/bin/run.sh <<EOF
 . /usr/local/etc/planet-env.sh
 export PATH=/usr/local/bin:$PATH
 
+# stop on error
 set -e
+# echo commands before executing them (useful to check that the arguments are correct)
+set -x
 
 python -u /usr/local/src/tileops/import/import.py --find-ip-address meta --date \$DATE \$TILE_ASSET_BUCKET \$AWS_DEFAULT_REGION \
        \$TILE_ASSET_PROFILE_ARN \$DB_PASSWORD
@@ -83,7 +86,7 @@ python -u /usr/local/src/tileops/batch-setup/make_tiles.py --num-db-replicas 10 
 python -u /usr/local/src/tileops/batch-setup/make_rawr_tiles.py --config enqueue-rawr-batch.config.yaml --key-format-type hash-prefix \
        \$RAWR_BUCKET \$DATE_PREFIX \$MISSING_BUCKET
 python -u /usr/local/src/tileops/batch-setup/make_meta_tiles.py --date-prefix \$DATE_PREFIX --missing-bucket \$MISSING_BUCKET \
-       --key-format-type hash-prefix --metatile_size \$METATILE_SIZE \$RAWR_BUCKET \$META_BUCKET \$DATE_PREFIX
+       --key-format-type hash-prefix --metatile-size \$METATILE_SIZE \$RAWR_BUCKET \$META_BUCKET \$DATE_PREFIX
 EOF
 chmod +x /usr/local/bin/run.sh
 

--- a/import/import.py
+++ b/import/import.py
@@ -52,6 +52,9 @@ if args.date is None:
 else:
     planet_date = datetime.datetime.strptime(args.date, '%Y-%m-%d').date()
 
+# if there's a snapshot already, then exit.
+assert_no_snapshot(planet_date)
+
 # NOTE: getattr usage here is to work around the bug in argparse where it
 # doesn't replace - with _ when setting positional argument attribute names.
 # it works ok with optional arguments, though.
@@ -66,9 +69,6 @@ elif args.find_ip_address == 'meta':
 else:
     assert 0, '--find-ip-address <ipify|meta>'
 
-
-# if there's a snapshot already, then exit.
-assert_no_snapshot(planet_date)
 
 osm2pgsql.ensure_import(
     planet_date, db, getattr(args, 'iam-instance-profile'), args.bucket,


### PR DESCRIPTION
I made a bunch of silly bugs, including:

1. Adding the `-max-zoom` argument to _the wrong external command_.
2. Forgetting to check for other uses of `MissingTileFinder`, whose signature I'd changed so that it no longer worked from the other invocation site.
3. Checking whether a database snapshot existed _after_ a different check, where the other check was erroring out rather than skipping the import without error.