### PR TITLE
Allow specifying code versions in Codebuild environment

### DIFF
--- a/buildspec.yml
+++ b/buildspec.yml
@@ -26,4 +26,4 @@ phases:
                          grep "Location: " |
                          sed 's,.*/planet-\([0-9]\{6\}\).osm.bz2\r$,\1,;t ok;q 1;:ok'`;
           fi
-      - pipenv run python batch-setup/cron.py --bucket-prefix $BUCKET_PREFIX --raw-tiles-version $RAW_TILES_VERSION --tilequeue-version $TILEQUEUE_VERSION --vector-datasource-version $VECTOR_DATASOURCE_VERSION --tileops-version $TILEOPS_VERSION $PLANET_DATE
+      - pipenv run python batch-setup/cron.py --bucket-prefix $BUCKET_PREFIX --raw-tiles-version $RAW_TILES_VERSION --tilequeue-version $TILEQUEUE_VERSION --vector-datasource-version $VECTOR_DATASOURCE_VERSION --tileops-version $TILEOPS_VERSION --ec2-instance-type t2.medium $PLANET_DATE

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -6,6 +6,11 @@ env:
     BUCKET_PREFIX: ""
     # this is set to the latest available planet if you don't override it in the GUI!
     PLANET_DATE: ""
+    # versions (git hashes, branches or tags) of software to install on the TPS instance. note that the version of cron.py that's run is determined by the uploaded version of the codebuild package, not this environment variable!
+    RAW_TILES_VERSION: master
+    TILEQUEUE_VERSION: master
+    VECTOR_DATASOURCE_VERSION: master
+    TILEOPS_VERSION: master
 
 phases:
   install:
@@ -21,4 +26,4 @@ phases:
                          grep "Location: " |
                          sed 's,.*/planet-\([0-9]\{6\}\).osm.bz2\r$,\1,;t ok;q 1;:ok'`;
           fi
-      - pipenv run python batch-setup/cron.py --bucket-prefix $BUCKET_PREFIX $PLANET_DATE
+      - pipenv run python batch-setup/cron.py --bucket-prefix $BUCKET_PREFIX --raw-tiles-version $RAW_TILES_VERSION --tilequeue-version $TILEQUEUE_VERSION --vector-datasource-version $VECTOR_DATASOURCE_VERSION --tileops-version $TILEOPS_VERSION $PLANET_DATE

--- a/utils/cwtail.py
+++ b/utils/cwtail.py
@@ -34,15 +34,19 @@ if log_stream is None:
 last_time = None
 while True:
     response = logs.get_log_events(
-        logGroupName=log_group, logStreamName=log_stream, limit=150,
+        logGroupName=log_group, logStreamName=log_stream, limit=200,
         startFromHead=False)
 
+    max_ingest_time = None
     for event in response['events']:
         ingest_time = event['ingestionTime']
         # any integer is greater than None, so we don't need to check for
-        # last_time is None
-        if ingest_time > last_time:
+        # last_time / max_ingest_time is None
+        if ingest_time > last_time and ingest_time >= max_ingest_time:
             print(event['message'])
-            last_time = ingest_time
+        if ingest_time > max_ingest_time:
+            max_ingest_time = ingest_time
+    if max_ingest_time > last_time:
+        last_time = max_ingest_time
 
     time.sleep(args.interval)


### PR DESCRIPTION
The major change here is to allow specifying code versions in the Codebuild environment. This allows us to kick off one-off jobs from branched code, or to pin code versions for regular scheduled builds.

Also, there's a change which uses `t2.medium` instead of `t2.micro` for the TPS instance. I'd prefer to use the smaller instance, but it turns out that 1GiB of memory isn't enough to compile coanacatl. @iandees is there any way to precompile the extension in that package so it doesn't need to be compiled at install time? Quite apart from the extra RAM it needs, it takes quite a long time!

Also, a couple of unrelated (sorry) changes to utilities to allow more configurability in the job queue monitor and better event filtering in the log watcher.