### PR TITLE
Configure meta date prefix separately

### DIFF
--- a/batch-setup/cron.py
+++ b/batch-setup/cron.py
@@ -512,9 +512,6 @@ if __name__ == '__main__':
 
     args = parser.parse_args()
     planet_date = datetime.strptime(args.date, '%y%m%d')
-    meta_date_prefix = (args.meta_date_prefix or
-                        os.environ.get('META_DATE_PREFIX') or
-                        planet_date)
 
     region = args.region or os.environ.get('AWS_DEFAULT_REGION')
     if region is None:
@@ -553,6 +550,9 @@ if __name__ == '__main__':
         Bucket(meta_bucket, date_prefix),
         Bucket(missing_bucket, date_prefix),
     )
+    meta_date_prefix = (args.meta_date_prefix or
+                        os.environ.get('META_DATE_PREFIX') or
+                        date_prefix)
 
     iam = boto3.client('iam')
 

--- a/batch-setup/cron.py
+++ b/batch-setup/cron.py
@@ -505,9 +505,16 @@ if __name__ == '__main__':
                         'tileops software to use on the TPS instance.')
     parser.add_argument('--metatile-size', default=8, type=int,
                         help='Metatile size (in 256px tiles).')
+    parser.add_argument('--meta-date-prefix', help='Meta tile bucket '
+                        'date prefix, defaults to planet date. You can '
+                        'also set the environment variable '
+                        'META_DATE_PREFIX.')
 
     args = parser.parse_args()
     planet_date = datetime.strptime(args.date, '%y%m%d')
+    meta_date_prefix = (args.meta_date_prefix or
+                        os.environ.get('META_DATE_PREFIX') or
+                        planet_date)
 
     region = args.region or os.environ.get('AWS_DEFAULT_REGION')
     if region is None:
@@ -584,6 +591,7 @@ if __name__ == '__main__':
         vector_datasource_version=args.vector_datasource_version,
         tileops_version=args.tileops_version,
         metatile_size=args.metatile_size,
+        meta_date_prefix=meta_date_prefix,
     )
 
     script_dir = os.path.dirname(os.path.realpath(__file__))

--- a/batch-setup/provision.sh
+++ b/batch-setup/provision.sh
@@ -44,6 +44,7 @@ export MISSING_BUCKET='%(missing_bucket)s'
 export DATE='%(date_iso)s'
 export PLANET_DATE='%(planet_date)s'
 export DATE_PREFIX='%(planet_date)s'
+export META_DATE_PREFIX='%(meta_date_prefix)s'
 
 export RAW_TILES_VERSION='%(raw_tiles_version)s'
 export TILEQUEUE_VERSION='%(tilequeue_version)s'
@@ -85,7 +86,7 @@ python -u /usr/local/src/tileops/batch-setup/make_tiles.py --num-db-replicas 10 
        \$META_BUCKET \$DB_PASSWORD
 python -u /usr/local/src/tileops/batch-setup/make_rawr_tiles.py --config enqueue-rawr-batch.config.yaml --key-format-type hash-prefix \
        \$RAWR_BUCKET \$DATE_PREFIX \$MISSING_BUCKET
-python -u /usr/local/src/tileops/batch-setup/make_meta_tiles.py --date-prefix \$DATE_PREFIX --missing-bucket \$MISSING_BUCKET \
+python -u /usr/local/src/tileops/batch-setup/make_meta_tiles.py --date-prefix \$META_DATE_PREFIX --missing-bucket \$MISSING_BUCKET \
        --key-format-type hash-prefix --metatile-size \$METATILE_SIZE \$RAWR_BUCKET \$META_BUCKET \$DATE_PREFIX
 EOF
 chmod +x /usr/local/bin/run.sh

--- a/docker/meta-batch/requirements.txt
+++ b/docker/meta-batch/requirements.txt
@@ -27,4 +27,4 @@ zope.dottedname==4.2
 edtf==2.6.0
 mapbox-vector-tile==1.2.0
 boto3==1.7.10
-git+https://github.com/tilezen/coanacatl@v0.1.0#egg=coanacatl
+git+https://github.com/tilezen/coanacatl@v0.2.0#egg=coanacatl

--- a/docker/meta-low-zoom-batch/requirements.txt
+++ b/docker/meta-low-zoom-batch/requirements.txt
@@ -27,4 +27,4 @@ zope.dottedname==4.2
 edtf==2.6.0
 mapbox-vector-tile==1.2.0
 boto3==1.7.10
-git+https://github.com/tilezen/coanacatl@v0.1.0#egg=coanacatl
+git+https://github.com/tilezen/coanacatl@v0.2.0#egg=coanacatl


### PR DESCRIPTION
To allow for a separate build re-using the databases and RAWR tiles, but making sure we're not mixing up with previous tiles in the meta tile bucket. Also bump coanacatl version to get Y coordinate flip fix.