### PR TITLE
Add meta date prefix to call to make_tiles.py

### DIFF
--- a/batch-setup/batch.py
+++ b/batch-setup/batch.py
@@ -495,6 +495,11 @@ def terminate_all_jobs(job_queue, reason):
                 jobStatus=status,
                 nextToken=next_token,
             )
-        print("Terminating %d %r jobs" % (len(job_ids), status))
-        for job_id in job_ids:
-            batch.terminate_job(jobId=job_id, reason=reason)
+        if status in ('SUBMITTED', 'PENDING', 'RUNNABLE'):
+            print("Cancelling %d %r jobs" % (len(job_ids), status))
+            for job_id in job_ids:
+                batch.cancel_job(jobId=job_id, reason=reason)
+        else:
+            print("Terminating %d %r jobs" % (len(job_ids), status))
+            for job_id in job_ids:
+                batch.terminate_job(jobId=job_id, reason=reason)

--- a/batch-setup/cancel_all_jobs.py
+++ b/batch-setup/cancel_all_jobs.py
@@ -1,31 +1,13 @@
-import boto3
 import argparse
+from batch import terminate_all_jobs
 
 
 parser = argparse.ArgumentParser("cancel all the jobs")
 parser.add_argument("date", help="Date prefix to use, YYMMDD.")
+parser.add_argument("--reason", help="Reason message to use. ",
+                    default="Manually terminating run due to bugs or "
+                    "misconfiguration.")
 args = parser.parse_args()
 
 job_queue = 'job-queue-%s' % (args.date,)
-batch = boto3.client('batch')
-for status in ('SUBMITTED', 'PENDING', 'RUNNABLE', 'STARTING',
-               'RUNNING'):
-    job_ids = []
-    response = batch.list_jobs(
-        jobQueue=job_queue,
-        jobStatus=status,
-    )
-    while response.get('jobSummaryList'):
-        for j in response['jobSummaryList']:
-            job_ids.append(j['jobId'])
-        next_token = response.get('nextToken')
-        if not next_token:
-            break
-        response = batch.list_jobs(
-            jobQueue=job_queue,
-            jobStatus=status,
-            nextToken=next_token,
-        )
-    print("Terminating %d %r jobs" % (len(job_ids), status))
-    for job_id in job_ids:
-        batch.terminate_job(jobId=job_id, reason='Terminating this run due to software bugs.')
+terminate_all_jobs(job_queue, args.reason)

--- a/batch-setup/provision.sh
+++ b/batch-setup/provision.sh
@@ -82,8 +82,8 @@ set -x
 
 python -u /usr/local/src/tileops/import/import.py --find-ip-address meta --date \$DATE \$TILE_ASSET_BUCKET \$AWS_DEFAULT_REGION \
        \$TILE_ASSET_PROFILE_ARN \$DB_PASSWORD
-python -u /usr/local/src/tileops/batch-setup/make_tiles.py --num-db-replicas 10 \$PLANET_DATE --missing-bucket \$MISSING_BUCKET \$RAWR_BUCKET \
-       \$META_BUCKET \$DB_PASSWORD
+python -u /usr/local/src/tileops/batch-setup/make_tiles.py --num-db-replicas 10 \$PLANET_DATE --missing-bucket \$MISSING_BUCKET \
+       --meta-date-prefix \$META_DATE_PREFIX \$RAWR_BUCKET \$META_BUCKET \$DB_PASSWORD
 python -u /usr/local/src/tileops/batch-setup/make_rawr_tiles.py --config enqueue-rawr-batch.config.yaml --key-format-type hash-prefix \
        \$RAWR_BUCKET \$DATE_PREFIX \$MISSING_BUCKET
 python -u /usr/local/src/tileops/batch-setup/make_meta_tiles.py --date-prefix \$META_DATE_PREFIX --missing-bucket \$MISSING_BUCKET \


### PR DESCRIPTION
Left this out of a previous PR, but the `make_tiles.py` script needs to know the meta date prefix, if it's different from the regular date prefix, so that it can set up the job definition and permissions correctly.

Also, an unrelated change to call `cancel_job` on some types of jobs - apparently terminate only works on running (or starting) jobs, and will silently fail on jobs in other statuses. Refactored the cancel all jobs script to use the code already in `batch.py`.