### PR TITLE
Better support for different prefix on meta bucket

### DIFF
--- a/batch-setup/make_rawr_tiles.py
+++ b/batch-setup/make_rawr_tiles.py
@@ -37,8 +37,8 @@ def missing_tiles(missing_bucket, rawr_bucket, date_prefix, region,
     present = set()
 
     finder = MissingTileFinder(
-        missing_bucket, rawr_bucket, date_prefix, region, key_format_type,
-        config, zoom)
+        missing_bucket, rawr_bucket, date_prefix, date_prefix, region,
+        key_format_type, config, zoom)
 
     with finder.present_tiles() as present_file:
         with open(present_file) as fh:

--- a/docker/meta-batch/requirements.txt
+++ b/docker/meta-batch/requirements.txt
@@ -27,4 +27,4 @@ zope.dottedname==4.2
 edtf==2.6.0
 mapbox-vector-tile==1.2.0
 boto3==1.7.10
-git+https://github.com/tilezen/coanacatl@v0.4.0#egg=coanacatl
+git+https://github.com/tilezen/coanacatl@v0.5.0#egg=coanacatl

--- a/docker/meta-low-zoom-batch/requirements.txt
+++ b/docker/meta-low-zoom-batch/requirements.txt
@@ -27,4 +27,4 @@ zope.dottedname==4.2
 edtf==2.6.0
 mapbox-vector-tile==1.2.0
 boto3==1.7.10
-git+https://github.com/tilezen/coanacatl@v0.4.0#egg=coanacatl
+git+https://github.com/tilezen/coanacatl@v0.5.0#egg=coanacatl

--- a/utils/cwtail.py
+++ b/utils/cwtail.py
@@ -1,6 +1,7 @@
 import boto3
 import time
 import argparse
+from datetime import datetime
 
 
 parser = argparse.ArgumentParser(
@@ -14,11 +15,25 @@ parser.add_argument('--stream', help='Name of log stream. Optional, defaults '
                     'to the stream in the group with the most recent events')
 parser.add_argument('--interval', default=60, type=int,
                     help='Interval between log updates.')
+parser.add_argument('--date', help='Planet date. If --stream is not supplied, '
+                    'look for a TPS instance tagged with this date. YYMMDD.')
 args = parser.parse_args()
 
 logs = boto3.client('logs')
 log_group = args.group
 log_stream = args.stream
+
+if log_stream is None and args.date:
+    planet_date = datetime.strptime(args.date, '%y%m%d')
+    long_date = planet_date.strftime('%Y-%m-%d')
+    ec2 = boto3.client('ec2')
+    response = ec2.describe_instances(
+        Filters=[dict(Name='tag:tps-instance', Values=[long_date])],
+    )
+    assert response['Reservations']
+    assert response['Reservations'][0]['Instances']
+    log_stream = response['Reservations'][0]['Instances'][0]['InstanceId']
+
 if log_stream is None:
     response = logs.describe_log_streams(
         logGroupName=log_group,


### PR DESCRIPTION
Add better support for having a different date prefix on the meta bucket vs. all other buckets.

Also, make it easier to tail logs for different environments, not just the most recent.

Finally, bump `coanacatl` version to latest to pick up bug fix.