### PR TITLE
Use run ID instead of date prefix for resource naming.

### DIFF
--- a/batch-setup/ecr.py
+++ b/batch-setup/ecr.py
@@ -27,9 +27,8 @@ def ensure_repo(ecr, repo_name):
     return repo_uri
 
 
-def ensure_ecr(planet_date):
+def ensure_ecr(run_id):
     ecr = boto3.client('ecr')
-    date_suffix = planet_date.strftime('%y%m%d')
 
     repo_names = (
         'meta-low-zoom-batch',
@@ -40,7 +39,7 @@ def ensure_ecr(planet_date):
 
     repo_uris = {}
     for repo_name in repo_names:
-        full_name = 'tilezen/%s-%s' % (repo_name, date_suffix)
+        full_name = 'tilezen/%s-%s' % (repo_name, run_id)
         repo_uris[repo_name] = ensure_repo(ecr, full_name)
 
     return repo_uris

--- a/batch-setup/make_meta_tiles.py
+++ b/batch-setup/make_meta_tiles.py
@@ -1,9 +1,9 @@
 from batch import Buckets
 from batch import run_go
-from datetime import datetime
 import yaml
 from make_rawr_tiles import wait_for_jobs_to_finish
 from make_rawr_tiles import wc_line
+from run_id import assert_run_id_format
 from contextlib import contextmanager
 from collections import namedtuple
 import boto3
@@ -197,9 +197,9 @@ if __name__ == '__main__':
     parser.add_argument('meta_bucket', help="Bucket with meta tiles in")
     parser.add_argument('--missing-bucket', help="Bucket to store missing "
                         "tile logs in")
-    parser.add_argument('date', help='Planet date, YYMMDD')
+    parser.add_argument('run_id', help='Unique identifier for run.')
     parser.add_argument('--date-prefix', help="Date prefix in bucket, "
-                        "defaults to planet date.")
+                        "defaults to run ID.")
     parser.add_argument('--retries', default=5, type=int, help="Number "
                         "of times to retry enqueueing the remaining jobs "
                         "before giving up.")
@@ -225,11 +225,11 @@ if __name__ == '__main__':
                         help='Metatile size (in 256px tiles).')
 
     args = parser.parse_args()
-    planet_date = datetime.strptime(args.date, '%y%m%d')
+    assert_run_id_format(args.run_id)
     buckets = Buckets(args.rawr_bucket, args.meta_bucket,
                       args.missing_bucket or args.meta_bucket)
-    date_prefix = args.date_prefix or planet_date.strftime('%y%m%d')
-    missing_bucket_date_prefix = planet_date.strftime('%y%m%d')
+    date_prefix = args.date_prefix or args.run_id
+    missing_bucket_date_prefix = args.run_id
     assert args.key_format_type in ('prefix-hash', 'hash-prefix')
 
     # TODO: split zoom and zoom max should come from config.

--- a/batch-setup/provision.sh
+++ b/batch-setup/provision.sh
@@ -42,8 +42,7 @@ export META_BUCKET='%(meta_bucket)s'
 export MISSING_BUCKET='%(missing_bucket)s'
 
 export DATE='%(date_iso)s'
-export PLANET_DATE='%(planet_date)s'
-export DATE_PREFIX='%(planet_date)s'
+export RUN_ID='%(run_id)s'
 export META_DATE_PREFIX='%(meta_date_prefix)s'
 
 export RAW_TILES_VERSION='%(raw_tiles_version)s'
@@ -82,12 +81,12 @@ set -x
 
 python -u /usr/local/src/tileops/import/import.py --find-ip-address meta --date \$DATE \$TILE_ASSET_BUCKET \$AWS_DEFAULT_REGION \
        \$TILE_ASSET_PROFILE_ARN \$DB_PASSWORD
-python -u /usr/local/src/tileops/batch-setup/make_tiles.py --num-db-replicas 10 \$PLANET_DATE --missing-bucket \$MISSING_BUCKET \
+python -u /usr/local/src/tileops/batch-setup/make_tiles.py --num-db-replicas 10 \$RUN_ID --missing-bucket \$MISSING_BUCKET \
        --meta-date-prefix \$META_DATE_PREFIX \$RAWR_BUCKET \$META_BUCKET \$DB_PASSWORD
 python -u /usr/local/src/tileops/batch-setup/make_rawr_tiles.py --config enqueue-rawr-batch.config.yaml --key-format-type hash-prefix \
-       \$RAWR_BUCKET \$DATE_PREFIX \$MISSING_BUCKET
+       \$RAWR_BUCKET \$RUN_ID \$MISSING_BUCKET
 python -u /usr/local/src/tileops/batch-setup/make_meta_tiles.py --date-prefix \$META_DATE_PREFIX --missing-bucket \$MISSING_BUCKET \
-       --key-format-type hash-prefix --metatile-size \$METATILE_SIZE \$RAWR_BUCKET \$META_BUCKET \$DATE_PREFIX
+       --key-format-type hash-prefix --metatile-size \$METATILE_SIZE \$RAWR_BUCKET \$META_BUCKET \$RUN_ID
 EOF
 chmod +x /usr/local/bin/run.sh
 

--- a/batch-setup/rds.py
+++ b/batch-setup/rds.py
@@ -102,8 +102,8 @@ def set_databases_security_group(rds, security_group_id, databases):
         )
 
 
-def ensure_dbs(planet_date, num_instances):
-    snapshot_id = planet_date.strftime('postgis-prod-%Y%m%d')
+def ensure_dbs(run_id, num_instances):
+    snapshot_id = 'postgis-prod-' + run_id
     rds = boto3.client('rds')
 
     if not does_snapshot_exist(rds, snapshot_id):

--- a/batch-setup/run_id.py
+++ b/batch-setup/run_id.py
@@ -1,0 +1,18 @@
+import re
+import sys
+
+
+def assert_run_id_format(run_id):
+    """
+    Checks that the run ID has a format that means we can use it in resource
+    names, directory and file names, etc... without any problems. Many AWS
+    resources are quite restrictive in terms of the characters that they can
+    contain.
+    """
+
+    m = re.match('^[a-zA-Z0-9]([a-zA-Z0-9-]*[a-zA-Z0-9])?$', run_id)
+    if m is None:
+        print("Run ID %r is badly formed. Run IDs may only contain ASCII "
+              "letters, numbers and dashes. Dashes may not appear at the "
+              "beginning or end of the run ID." % (run_id,))
+        sys.exit(1)

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -6,6 +6,8 @@ env:
     BUCKET_PREFIX: ""
     # this is set to the latest available planet if you don't override it in the GUI!
     PLANET_DATE: ""
+    # set this to a unique identifier for the run. Defaults to the planet date.
+    RUN_ID: ""
     # versions (git hashes, branches or tags) of software to install on the TPS instance. note that the version of cron.py that's run is determined by the uploaded version of the codebuild package, not this environment variable!
     RAW_TILES_VERSION: master
     TILEQUEUE_VERSION: master
@@ -26,4 +28,9 @@ phases:
                          grep "Location: " |
                          sed 's,.*/planet-\([0-9]\{6\}\).osm.bz2\r$,\1,;t ok;q 1;:ok'`;
           fi
-      - pipenv run python batch-setup/cron.py --bucket-prefix $BUCKET_PREFIX --raw-tiles-version $RAW_TILES_VERSION --tilequeue-version $TILEQUEUE_VERSION --vector-datasource-version $VECTOR_DATASOURCE_VERSION --tileops-version $TILEOPS_VERSION --ec2-instance-type t2.medium $PLANET_DATE
+      # set a run ID to the planet date, if it wasn't already overridden in the environment.
+      - >
+          if [ -z "$RUN_ID" ]; then
+            RUN_ID="$PLANET_DATE";
+          fi
+      - pipenv run python batch-setup/cron.py --bucket-prefix $BUCKET_PREFIX --raw-tiles-version $RAW_TILES_VERSION --tilequeue-version $TILEQUEUE_VERSION --vector-datasource-version $VECTOR_DATASOURCE_VERSION --tileops-version $TILEOPS_VERSION --ec2-instance-type t2.medium --run-id $RUN_ID $PLANET_DATE

--- a/import/database.py
+++ b/import/database.py
@@ -62,8 +62,8 @@ def ensure_vpc_security_group(security_group_name):
     return sg_id
 
 
-def ensure_database(planet_date, master_user_password):
-    instance_id = planet_date.strftime('postgis-prod-%Y%m%d')
+def ensure_database(run_id, master_user_password):
+    instance_id = 'postgis-prod-' + run_id
 
     rds = boto3.client('rds')
 
@@ -126,8 +126,8 @@ def ensure_database(planet_date, master_user_password):
     )
 
 
-def take_snapshot_and_shutdown(db, planet_date):
-    instance_id = planet_date.strftime('postgis-prod-%Y%m%d')
+def take_snapshot_and_shutdown(db, run_id):
+    instance_id = 'postgis-prod-' + run_id
 
     rds = boto3.client('rds')
 

--- a/utils/cwtail.py
+++ b/utils/cwtail.py
@@ -1,7 +1,6 @@
 import boto3
 import time
 import argparse
-from datetime import datetime
 
 
 parser = argparse.ArgumentParser(
@@ -15,20 +14,20 @@ parser.add_argument('--stream', help='Name of log stream. Optional, defaults '
                     'to the stream in the group with the most recent events')
 parser.add_argument('--interval', default=60, type=int,
                     help='Interval between log updates.')
-parser.add_argument('--date', help='Planet date. If --stream is not supplied, '
-                    'look for a TPS instance tagged with this date. YYMMDD.')
+parser.add_argument('--run-id', help='Unique run identifier. If --stream is '
+                    'not supplied, look for a TPS instance tagged with this '
+                    'ID.')
 args = parser.parse_args()
 
 logs = boto3.client('logs')
 log_group = args.group
 log_stream = args.stream
 
-if log_stream is None and args.date:
-    planet_date = datetime.strptime(args.date, '%y%m%d')
-    long_date = planet_date.strftime('%Y-%m-%d')
+if log_stream is None and args.run_id:
+    run_id = args.run_id
     ec2 = boto3.client('ec2')
     response = ec2.describe_instances(
-        Filters=[dict(Name='tag:tps-instance', Values=[long_date])],
+        Filters=[dict(Name='tag:tps-instance', Values=[run_id])],
     )
     assert response['Reservations']
     assert response['Reservations'][0]['Instances']


### PR DESCRIPTION
Previously, all runs had been identified by the planet date they're generated from. This leads to problems when we want to run two concurrent, different runs off the same planet. To make sure resources are unique to the run rather than the planet file, this PR changes to name resources using the run ID instead. The previous behaviour should be (almost) emulated by specifying the run ID as `YYMMDD`.

There are a few things, notably PostgreSQL database names, which used a `YYYY-MM-DD` format instead, and these will be incompatible. However, I think the gain is worth the hassle of having to manually go back and correct any of those which might still be running.

Possibly helps towards #16.