### PR TITLE
Propagate vector datasource version to import.py. 

### DIFF
--- a/batch-setup/provision.sh
+++ b/batch-setup/provision.sh
@@ -79,7 +79,7 @@ set -e
 # echo commands before executing them (useful to check that the arguments are correct)
 set -x
 
-python -u /usr/local/src/tileops/import/import.py --find-ip-address meta --date \$DATE --run-id \$RUN_ID \$TILE_ASSET_BUCKET \$AWS_DEFAULT_REGION \
+python -u /usr/local/src/tileops/import/import.py --find-ip-address meta --date \$DATE --run-id \$RUN_ID --vector-datasource-version \$VECTOR_DATASOURCE_VERSION \$TILE_ASSET_BUCKET \$AWS_DEFAULT_REGION \
        \$TILE_ASSET_PROFILE_ARN \$DB_PASSWORD
 python -u /usr/local/src/tileops/batch-setup/make_tiles.py --num-db-replicas 10 \$RUN_ID --missing-bucket \$MISSING_BUCKET \
        --meta-date-prefix \$META_DATE_PREFIX \$RAWR_BUCKET \$META_BUCKET \$DB_PASSWORD

--- a/upload_to_codebuild.sh
+++ b/upload_to_codebuild.sh
@@ -8,9 +8,9 @@ usage() {
     cat <<EOF >&2
 Usage: $0 -b BUCKET [-p PREFIX] [-t TREEISH] [-k KEY]
   BUCKET:  The S3 bucket to upload to.
-  PREFIX:  The prefix within the bucket, if any.
+  PREFIX:  The prefix within the bucket, if any. Note: this adds a trailing /, unless PREFIX is empty.
   TREEISH: Git description of the version to upload, defaults to HEAD.
-  KEY:     The key to use under the bucket and prefix. Defaults to "tileops-$DESC.zip" where DESC is built from the git version.
+  KEY:     The key to use under the bucket and prefix. Defaults to "tileops-\$DESC.zip" where DESC is built from the git version.
 EOF
     exit 1
 }


### PR DESCRIPTION
Also: Better usage comments for upload_to_codebuild.sh.

Minor change, so I'll go ahead and just merge it, but please review and tell me if you see any problems.