### PR TITLE
Temporary hack around pip/pipenv clash

### DIFF
--- a/buildspec.yml
+++ b/buildspec.yml
@@ -18,6 +18,8 @@ phases:
   install:
     commands:
       - pip install pipenv
+      # temporary hack around https://github.com/pypa/pipenv/issues/2924
+      - pipenv run pip install pip==18.0
       - pipenv sync
   build:
     commands:


### PR DESCRIPTION
It looks like [Pipenv depended on an underscore-prefixed symbol from Pip which got removed in the latest version](https://github.com/pypa/pipenv/issues/2924). Until a new version of Pipenv is released, looks like the work-around is to hold the version of Pip at 18.0.