### PR TITLE
Fix some issues with setup script

### DIFF
--- a/import/database_looks_finished.sh
+++ b/import/database_looks_finished.sh
@@ -7,7 +7,10 @@ export PGDATABASE='%(db_name)s'
 export PGUSER='%(db_user)s'
 
 # we expect to have data in all these tables, if we ran to completion.
-read -d ' ' ALL_TABLES=<<EOF
+# NOTE: planet_osm_nodes is _intentionally_ missing, since we run with
+# the external flat nodes file for node storage, so the table ought to
+# be empty.
+read -d ' ' ALL_TABLES <<EOF
 buffered_land
 land_polygons
 ne_10m_admin_0_boundary_lines_land
@@ -35,7 +38,6 @@ ne_50m_ocean
 ne_50m_playas
 ne_50m_urban_areas
 planet_osm_line
-planet_osm_nodes
 planet_osm_point
 planet_osm_polygon
 planet_osm_rels

--- a/utils/setup.sh
+++ b/utils/setup.sh
@@ -141,7 +141,7 @@ if [ -z "$ACCOUNT_ID" ]; then
     exit 1
 fi
 
-title "Checking or Codebuild TPS policy"
+title "Checking for Codebuild TPS policy"
 aws iam get-policy --policy-arn "arn:aws:iam::${ACCOUNT_ID}:policy/AllowCodebuildToStartTPS" >/dev/null 2>&1 || error_exit
 if [ $? -ne 0 ]; then
     title "Creating a policy for Codebuild TPS"

--- a/utils/setup.sh
+++ b/utils/setup.sh
@@ -75,7 +75,10 @@ go get github.com/aws/aws-sdk-go
 go get gopkg.in/yaml.v2
 
 title "Building static Go tools"
-(cd "${GOPATH}/src/tzops/go" && go install ./...)
+# NOTE: CGO_ENABLED=0 is provided to _not_ link the system C library. this is
+# so that we don't get mismatches between most desktop Linux environments
+# (which use GNU libc) and Alpine Linux (which uses MUSL).
+(cd "${GOPATH}/src/tzops/go" && CGO_ENABLED=0 go install ./...)
 
 title "Uploading Go tools to S3"
 for i in tz-batch-create-job-definition \

--- a/utils/setup.sh
+++ b/utils/setup.sh
@@ -107,7 +107,7 @@ StreetNames==0.1.5
 Werkzeug==0.12.2
 appdirs==1.4.3
 argparse==1.4.0
-boto3==1.7.10
+boto3==1.9.32
 boto==2.48.0
 edtf==2.6.0
 enum34==1.1.6

--- a/utils/setup.sh
+++ b/utils/setup.sh
@@ -64,7 +64,7 @@ export GOARCH=amd64
 export AWS_DEFAULT_REGION="${REGION}"
 
 title "Creating S3 buckets"
-for func in tile-assets rawr-tiles missing-bucket meta-tiles; do
+for func in tile-assets rawr-tiles missing-tiles meta-tiles; do
    aws s3 mb "s3://${PREFIX}-${func}-${REGION}" --region "${REGION}"
 done
 


### PR DESCRIPTION
There were a couple of big problems which meant the environment hadn't been set up correctly, so I've tried to back-port these to the setup script.

1. On my desktop Linux system, Go binaries were dynamically linked to `libc`, which works great on my system. However, on an Alpine Linux container, which uses a different `libc` implementation, it failed to run. Fixed this by disabling CGO, which seems to be the default behaviour when cross-compiling on Mac OS.
2. Use the correct name for the missing tiles bucket :man_facepalming: 
3. Add an `ecsInstanceRole` role and instance profile which match what we default to in the scripts.
