### PR TITLE
Allow configuring job overrides

### DIFF
--- a/batch-setup/cron.py
+++ b/batch-setup/cron.py
@@ -511,6 +511,8 @@ if __name__ == '__main__':
                         'META_DATE_PREFIX.')
     parser.add_argument('--run-id', help='Distinctive run ID to give to '
                         'this build. Defaults to planet date YYMMDD.')
+    parser.add_argument('--job-env-overrides', default=[], nargs='*',
+                        help='Overrides for the Batch job environment.')
 
     args = parser.parse_args()
     planet_date = datetime.strptime(args.date, '%y%m%d')
@@ -591,6 +593,7 @@ if __name__ == '__main__':
         tileops_version=args.tileops_version,
         metatile_size=args.metatile_size,
         meta_date_prefix=meta_date_prefix,
+        job_env_overrides=" ".join(args.job_env_overrides),
     )
 
     script_dir = os.path.dirname(os.path.realpath(__file__))

--- a/batch-setup/make_tiles.py
+++ b/batch-setup/make_tiles.py
@@ -40,6 +40,12 @@ parser.add_argument('--meta-date-prefix', help='Optional different date '
 parser.add_argument('--check-metatile-exists', default=False,
                     action='store_true', help='Whether to check if the '
                     'metatile exists first before processing the batch job.')
+parser.add_argument('--overrides', nargs='*', default=[], help='List of '
+                    'KEY=VALUE pairs to use when overriding environment '
+                    'variables in Batch jobs. Prefix the KEY with the '
+                    'uppercase, underscore-delimited, '
+                    'double-underscore-separated name of the batch job, e.g: '
+                    'META_BATCH__')
 
 args = parser.parse_args()
 run_id = args.run_id
@@ -51,6 +57,12 @@ if region is None:
     import sys
     print "ERROR: Need environment variable AWS_DEFAULT_REGION to be set."
     sys.exit(1)
+
+# unpack overrides into a dict, so it's easier to work with
+job_env_overrides = {}
+for kv in args.overrides:
+    key, value = kv.split('=', 1)
+    job_env_overrides[key] = value
 
 repo_uris = ensure_ecr(run_id)
 
@@ -93,7 +105,8 @@ job_def_names = create_job_definitions(
     run_id, region, repo_uris, database_ids, buckets, args.db_password,
     memory=memory, vcpus=vcpus, retry_attempts=retry_attempts,
     date_prefix=date_prefix, meta_date_prefix=args.meta_date_prefix,
-    check_metatile_exists=args.check_metatile_exists)
+    check_metatile_exists=args.check_metatile_exists,
+    overrides=job_env_overrides)
 
 # create config file for tilequeue
 for name in ('rawr-batch', 'meta-batch', 'meta-low-zoom-batch',

--- a/batch-setup/make_tiles.py
+++ b/batch-setup/make_tiles.py
@@ -106,7 +106,7 @@ job_def_names = create_job_definitions(
     memory=memory, vcpus=vcpus, retry_attempts=retry_attempts,
     date_prefix=date_prefix, meta_date_prefix=args.meta_date_prefix,
     check_metatile_exists=args.check_metatile_exists,
-    overrides=job_env_overrides)
+    job_env_overrides=job_env_overrides)
 
 # create config file for tilequeue
 for name in ('rawr-batch', 'meta-batch', 'meta-low-zoom-batch',

--- a/batch-setup/provision.sh
+++ b/batch-setup/provision.sh
@@ -50,6 +50,8 @@ export TILEQUEUE_VERSION='%(tilequeue_version)s'
 export VECTOR_DATASOURCE_VERSION='%(vector_datasource_version)s'
 
 export METATILE_SIZE='%(metatile_size)d'
+
+export JOB_ENV_OVERRIDES='%(job_env_overrides)s'
 eof
 
 mkdir /tmp/awslogs
@@ -84,7 +86,7 @@ python -u /usr/local/src/tileops/import/import.py --find-ip-address meta --date 
 python -u /usr/local/src/tileops/batch-setup/make_tiles.py --num-db-replicas 10 \$RUN_ID --missing-bucket \$MISSING_BUCKET \
        --meta-date-prefix \$META_DATE_PREFIX \$RAWR_BUCKET \$META_BUCKET \$DB_PASSWORD
 python -u /usr/local/src/tileops/batch-setup/make_rawr_tiles.py --config enqueue-rawr-batch.config.yaml --key-format-type hash-prefix \
-       \$RAWR_BUCKET \$RUN_ID \$MISSING_BUCKET
+       \$RAWR_BUCKET \$RUN_ID \$MISSING_BUCKET --overrides \$JOB_ENV_OVERRIDES
 python -u /usr/local/src/tileops/batch-setup/make_meta_tiles.py --date-prefix \$META_DATE_PREFIX --missing-bucket \$MISSING_BUCKET \
        --key-format-type hash-prefix --metatile-size \$METATILE_SIZE \$RAWR_BUCKET \$META_BUCKET \$RUN_ID
 EOF

--- a/batch-setup/provision.sh
+++ b/batch-setup/provision.sh
@@ -84,9 +84,10 @@ set -x
 python -u /usr/local/src/tileops/import/import.py --find-ip-address meta --date \$DATE --run-id \$RUN_ID --vector-datasource-version \$VECTOR_DATASOURCE_VERSION \$TILE_ASSET_BUCKET \$AWS_DEFAULT_REGION \
        \$TILE_ASSET_PROFILE_ARN \$DB_PASSWORD
 python -u /usr/local/src/tileops/batch-setup/make_tiles.py --num-db-replicas 10 \$RUN_ID --missing-bucket \$MISSING_BUCKET \
-       --meta-date-prefix \$META_DATE_PREFIX \$RAWR_BUCKET \$META_BUCKET \$DB_PASSWORD
+       --meta-date-prefix \$META_DATE_PREFIX \$RAWR_BUCKET \$META_BUCKET \
+       \$DB_PASSWORD --overrides \$JOB_ENV_OVERRIDES
 python -u /usr/local/src/tileops/batch-setup/make_rawr_tiles.py --config enqueue-rawr-batch.config.yaml --key-format-type hash-prefix \
-       \$RAWR_BUCKET \$RUN_ID \$MISSING_BUCKET --overrides \$JOB_ENV_OVERRIDES
+       \$RAWR_BUCKET \$RUN_ID \$MISSING_BUCKET
 python -u /usr/local/src/tileops/batch-setup/make_meta_tiles.py --date-prefix \$META_DATE_PREFIX --missing-bucket \$MISSING_BUCKET \
        --key-format-type hash-prefix --metatile-size \$METATILE_SIZE \$RAWR_BUCKET \$META_BUCKET \$RUN_ID
 EOF

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -13,6 +13,8 @@ env:
     TILEQUEUE_VERSION: master
     VECTOR_DATASOURCE_VERSION: master
     TILEOPS_VERSION: master
+    # overrides for Batch job environment, which can override the config. for example, if we wanted to override the meta-batch S3 store name (i.e: bucket), then we could set META_BATCH__TILEQUEUE__STORE__NAME=whatever.
+    JOB_ENV_OVERRIDES: ""
 
 phases:
   install:
@@ -35,4 +37,4 @@ phases:
           if [ -z "$RUN_ID" ]; then
             RUN_ID="$PLANET_DATE";
           fi
-      - pipenv run python batch-setup/cron.py --bucket-prefix $BUCKET_PREFIX --raw-tiles-version $RAW_TILES_VERSION --tilequeue-version $TILEQUEUE_VERSION --vector-datasource-version $VECTOR_DATASOURCE_VERSION --tileops-version $TILEOPS_VERSION --ec2-instance-type t2.medium --run-id $RUN_ID $PLANET_DATE
+      - pipenv run python batch-setup/cron.py --bucket-prefix $BUCKET_PREFIX --raw-tiles-version $RAW_TILES_VERSION --tilequeue-version $TILEQUEUE_VERSION --vector-datasource-version $VECTOR_DATASOURCE_VERSION --tileops-version $TILEOPS_VERSION --ec2-instance-type t2.medium --run-id $RUN_ID $PLANET_DATE --job-env-overrides $JOB_ENV_OVERRIDES


### PR DESCRIPTION
Allow overrides to be passed into `cron.py` (i.e: from CodeBuild) and which are passed through to the Batch job environment, which can override the configuration file built into the Docker container. For example, if we wanted to override the meta-batch S3 store name (i.e: bucket), then we could set the `JOB_ENV_OVERRIDES` environment variable to:

```
META_BATCH__TILEQUEUE__STORE__NAME=whatever
```

This allows us to make some small config changes on a run-by-run basis, and means that we don't have to fork the `tileops` repo to do it.
    