### PR TITLE
Use an instance profile in compute environment config.

### DIFF
--- a/batch-setup/cron.py
+++ b/batch-setup/cron.py
@@ -128,6 +128,8 @@ def create_tps_profile(iam, profile_name, locations):
                 'iam:CreateRole',
                 'iam:AttachRolePolicy',
                 'iam:PassRole',
+                'iam:GetInstanceProfile',
+                'iam:AddRoleToInstanceProfile',
             ],
             Resource='*',
         ),


### PR DESCRIPTION
Previously, we've been using an IAM role for this, but it looks like EC2/spot recently got a bit stricter about this being an instance profile (which is what the documentation says it should be). This adds the extra steps to create the instance profile at the same time as the role and pass it through when creating the compute environment.