### PR TITLE
Update requests to 2.20.0 because CVE-2018-18074.

### DIFF
--- a/docker/meta-batch/requirements.txt
+++ b/docker/meta-batch/requirements.txt
@@ -15,7 +15,7 @@ pyproj==1.9.5.1
 python-dateutil==2.6.1
 PyYAML==3.12
 redis==2.10.6
-requests==2.18.4
+requests==2.20.0
 Shapely==1.6.2.post1
 six==1.11.0
 StreetNames==0.1.5

--- a/docker/meta-low-zoom-batch/requirements.txt
+++ b/docker/meta-low-zoom-batch/requirements.txt
@@ -15,7 +15,7 @@ pyproj==1.9.5.1
 python-dateutil==2.6.1
 PyYAML==3.12
 redis==2.10.6
-requests==2.18.4
+requests==2.20.0
 Shapely==1.6.2.post1
 six==1.11.0
 StreetNames==0.1.5

--- a/docker/rawr-batch/requirements.txt
+++ b/docker/rawr-batch/requirements.txt
@@ -15,7 +15,7 @@ pyproj==1.9.5.1
 python-dateutil==2.6.1
 PyYAML==3.12
 redis==2.10.6
-requests==2.18.4
+requests==2.20.0
 Shapely==1.6.2.post1
 six==1.11.0
 StreetNames==0.1.5

--- a/import/requirements.txt
+++ b/import/requirements.txt
@@ -1,3 +1,3 @@
 boto3==1.6.4
 paramiko==2.4.2
-requests==2.18.4
+requests==2.20.0

--- a/utils/setup.sh
+++ b/utils/setup.sh
@@ -126,7 +126,7 @@ pycountry==17.9.23
 pyproj==1.9.5.1
 python-dateutil==2.6.1
 redis==2.10.6
-requests==2.18.4
+requests==2.20.0
 six==1.11.0
 statsd==3.2.1
 ujson==1.35


### PR DESCRIPTION
Fixes the security alert that Github pops up with on the repo! :lock: 