### PR TITLE
Make Mising Meta Multi Method

### DIFF
--- a/go/cmd/tz-missing-meta-tiles-write/missing-meta-tiles-write.go
+++ b/go/cmd/tz-missing-meta-tiles-write/missing-meta-tiles-write.go
@@ -2,9 +2,11 @@ package main
 
 import (
 	"bytes"
+	"encoding/json"
 	"flag"
 	"fmt"
 	"os"
+	"strings"
 	"tzops/go/pkg/cmd"
 	"tzops/go/pkg/coord"
 	tzs3 "tzops/go/pkg/s3"
@@ -58,30 +60,37 @@ func formatKey(hash, date string, keyFormatType KeyFormatType) string {
 	}
 }
 
-func listPrefix(hexPrefixChan <-chan string, coordsChan chan<- []coord.Coord, svc *s3.S3, srcBucket string, srcDatePrefix string, concurrency uint, keyFormatType KeyFormatType) {
+// listBucketPrefix lists all the coordinates it finds while scanning a given bucket in the given prefix to the coordsChan channel.
+func listBucketPrefix(coordsChan chan<- []coord.Coord, svc *s3.S3, srcBucket, prefix string) {
+	input := s3.ListObjectsInput{
+		Bucket: &srcBucket,
+		Prefix: &prefix,
+	}
+	err := svc.ListObjectsPages(&input, func(output *s3.ListObjectsOutput, lastPage bool) bool {
+		coords := make([]coord.Coord, 0, len(output.Contents))
+		for _, obj := range output.Contents {
+			key := *obj.Key
+			c, err := tzs3.ParseCoordFromKey(key)
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "Could not parse coordinate from %#v: %s\n", key, err)
+			} else {
+				coords = append(coords, *c)
+			}
+		}
+		coordsChan <- coords
+		return true
+	})
+	if err != nil {
+		panic(err)
+	}
+}
+
+func listPrefix(hexPrefixChan <-chan string, coordsChan chan<- []coord.Coord, svc *s3.S3, srcBuckets []string, srcDatePrefix string, concurrency uint, keyFormatType KeyFormatType) {
 	util.Concurrently(concurrency, func() {
 		for hexPrefix := range hexPrefixChan {
 			prefix := formatKey(hexPrefix, srcDatePrefix, keyFormatType)
-			input := s3.ListObjectsInput{
-				Bucket: &srcBucket,
-				Prefix: &prefix,
-			}
-			err := svc.ListObjectsPages(&input, func(output *s3.ListObjectsOutput, lastPage bool) bool {
-				coords := make([]coord.Coord, 0, len(output.Contents))
-				for _, obj := range output.Contents {
-					key := *obj.Key
-					c, err := tzs3.ParseCoordFromKey(key)
-					if err != nil {
-						fmt.Fprintf(os.Stderr, "Could not parse coordinate from %#v: %s\n", key, err)
-					} else {
-						coords = append(coords, *c)
-					}
-				}
-				coordsChan <- coords
-				return true
-			})
-			if err != nil {
-				panic(err)
+			for _, srcBucket := range srcBuckets {
+				listBucketPrefix(coordsChan, svc, srcBucket, prefix)
 			}
 		}
 	})
@@ -118,6 +127,20 @@ func writeCoords(coordsChan <-chan []coord.Coord, doneChan chan<- interface{}, s
 	doneChan <- struct{}{}
 }
 
+// isS3BucketName checks if the string looks like an S3 bucket name.
+//
+// According to the docs, more than just a-z, 0-9 and '-' are allowed (e.g: %, &, / - see https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/DomainNameFormat.html#domain-name-format-hosted-zones) but these look terribly confusing and I haven't seen them in widespread use. Underscores and upper case letters are now not allowed in bucket names, so I think we can assume they'd not be used either.
+func isS3BucketName(input string) bool {
+	for _, ch := range input {
+		if (ch < 'a' || ch > 'z') &&
+			(ch < '0' || ch > '9') &&
+			ch != '-' {
+			return false
+		}
+	}
+	return true
+}
+
 func main() {
 	var srcBucket string
 	var srcDatePrefix string
@@ -128,9 +151,10 @@ func main() {
 	var region string
 	var keyFormatTypeStr string
 	var keyFormatType KeyFormatType
+	var allBuckets bool
 
 	// TODO is this better to put in a yaml file?
-	flag.StringVar(&srcBucket, "src-bucket", "", "source s3 bucket to enumerate tiles")
+	flag.StringVar(&srcBucket, "src-bucket", "", "source s3 bucket to enumerate tiles. If multiple buckets, format as a JSON array _without spaces_.")
 	flag.StringVar(&srcDatePrefix, "src-date-prefix", "", "source date prefix")
 	flag.StringVar(&destBucket, "dest-bucket", "", "dest s3 bucket to write tiles")
 	flag.StringVar(&destDatePrefix, "dest-date-prefix", "", "dest date prefix to write tiles found")
@@ -138,6 +162,7 @@ func main() {
 	flag.UintVar(&concurrency, "concurrency", 16, "number of goroutines listing bucket per hash prefix")
 	flag.StringVar(&region, "region", "us-east-1", "region")
 	flag.StringVar(&keyFormatTypeStr, "key-format-type", "", "Either 'prefix-hash' or 'hash-prefix' to control the order of the date prefix and hash in the src S3 key.")
+	flag.BoolVar(&allBuckets, "all-buckets", false, "If true, check all buckets in list, not just the last one.")
 
 	flag.Parse()
 
@@ -161,6 +186,40 @@ func main() {
 		cmd.DieWithUsage()
 	}
 
+	// we support multiple buckets as src, in which case we check the last one.
+	var srcBuckets []string
+
+	// decode src bucket argument if it looks like an array.
+	if strings.HasPrefix(srcBucket, "[") && strings.HasSuffix(srcBucket, "]") {
+		err := json.Unmarshal([]byte(srcBucket), &srcBuckets)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "-src-bucket looks like JSON array, but there was an error while decoding it: %s\n", err.Error())
+			cmd.DieWithUsage()
+		}
+
+		numBuckets := len(srcBuckets)
+		if numBuckets < 1 {
+			fmt.Fprintf(os.Stderr, "Must provide at least one bucket to -src-bucket when using JSON array syntax\n")
+			cmd.DieWithUsage()
+		}
+
+	} else {
+		// add the single command line argument to the array
+		srcBuckets = append(srcBuckets, srcBucket)
+	}
+
+	for i, bucket := range srcBuckets {
+		if !isS3BucketName(bucket) {
+			fmt.Fprintf(os.Stderr, "-src-bucket %dth argument, %#v, does not look like an S3 bucket name. It should be all lower case ASCII letters and digits separated by hyphens.\n", i, bucket)
+			cmd.DieWithUsage()
+		}
+	}
+
+	if !allBuckets {
+		// we use only the last bucket to check whether the tile has been written. this is because tilequeue will write in order, so if it wrote the last one then it seems reasonable to assume it wrote all the previous ones.
+		srcBuckets = []string{srcBuckets[len(srcBuckets) - 1]}
+	}
+
 	sess := session.Must(session.NewSession(&aws.Config{
 		Region:     &region,
 		MaxRetries: aws.Int(10),
@@ -172,7 +231,7 @@ func main() {
 	doneChan := make(chan interface{})
 
 	go genHexPrefixes(hexPrefixChan, hexPrefix)
-	go listPrefix(hexPrefixChan, coordsChan, svc, srcBucket, srcDatePrefix, concurrency, keyFormatType)
+	go listPrefix(hexPrefixChan, coordsChan, svc, srcBuckets, srcDatePrefix, concurrency, keyFormatType)
 	go writeCoords(coordsChan, doneChan, svc, destBucket, destDatePrefix, hexPrefix)
 
 	<-doneChan


### PR DESCRIPTION
Passing a JSON-formatted array to the missing-meta-tiles-write `-src-bucket` parameter will cause it to check the last in the list. For completeness, and in case we need it later, also added an `-all-buckets` flag so that we can force it to check all the buckets, not just the last one.