### PR TITLE
Allow configuring multiple buckets from the environment

### DIFF
--- a/batch-setup/cron.py
+++ b/batch-setup/cron.py
@@ -535,12 +535,22 @@ if __name__ == '__main__':
     profile_name = args.profile_name or ('tps-'  + run_id)
 
     def bucket_name(arg_name, bucket_function):
+        # command line argument is most important
         prop_name = arg_name.lstrip('-').replace('-', '_')
         value = getattr(args, prop_name)
         if value:
             return value
+
+        # if that doesn't exist, look for an environment variable
+        env_name = prop_name.upper()
+        if env_name in os.environ:
+            return os.environ[env_name]
+
+        # otherwise, default to a value constructed from the bucket prefix.
         if args.bucket_prefix:
             return '%s-%s-%s' % (args.bucket_prefix, bucket_function, region)
+
+        # finally, error out if we can't figure out a value.
         raise RuntimeError('Must provide either --bucket-prefix or %s.'
                            % (arg_name,))
 


### PR DESCRIPTION
Adds the ability to configure bucket locations from the codebuild environment (i.e: as parameters in the codebuild UI). The **meta** bucket can also be a JSON-formatted list of buckets, in which case they're passed to the meta tile build and it'll write to multiple buckets.

Apart from https://github.com/tilezen/vector-datasource/pull/1706, an experimental build I've got running appears to be working OK.
