### PR TITLE
Don't set tags on S3 objects by default.

### DIFF
--- a/batch-setup/batch.py
+++ b/batch-setup/batch.py
@@ -55,20 +55,12 @@ def env_for_image(name, db_hosts, db_name, db_user, db_password, buckets,
             'TILEQUEUE__RAWR__SINK__S3__BUCKET': buckets.rawr,
             'TILEQUEUE__RAWR__SINK__S3__REGION': region,
             'TILEQUEUE__RAWR__SINK__S3__PREFIX': date_prefixes.rawr,
-            'TILEQUEUE__RAWR__SINK__S3__TAGS': dict(
-                prefix=date_prefixes.rawr,
-                run_id=date_prefixes.rawr,
-            ),
         }
 
     elif name == 'meta-batch':
         env = {
             'TILEQUEUE__STORE__NAME': buckets.meta,
             'TILEQUEUE__STORE__DATE-PREFIX': date_prefixes.meta,
-            'TILEQUEUE__STORE__TAGS': dict(
-                prefix=date_prefixes.meta,
-                run_id=date_prefixes.meta,
-            ),
             'TILEQUEUE__RAWR__SOURCE__S3__BUCKET': buckets.rawr,
             'TILEQUEUE__RAWR__SOURCE__S3__REGION': region,
             'TILEQUEUE__RAWR__SOURCE__S3__PREFIX': date_prefixes.rawr,
@@ -83,10 +75,6 @@ def env_for_image(name, db_hosts, db_name, db_user, db_password, buckets,
             'TILEQUEUE__POSTGRESQL__PASSWORD': db_password,
             'TILEQUEUE__STORE__NAME': buckets.meta,
             'TILEQUEUE__STORE__DATE-PREFIX': date_prefixes.meta,
-            'TILEQUEUE__STORE__TAGS': dict(
-                prefix=date_prefixes.meta,
-                run_id=date_prefixes.meta,
-            ),
             'TILEQUEUE__BATCH__CHECK-METATILE-EXISTS': check_metatile_exists,
         }
 


### PR DESCRIPTION
Turns out, S3 tags are [pretty expensive](https://aws.amazon.com/s3/pricing/) - at current prices, putting two tags on each is equivalent to storing an extra 100kB. And most metatiles aren't even that big, as most are just water (about 4kB).

We had originally envisioned the tags as a neat way to tell which dataset a metatile was part of, which run rendered it, and as a quick way to delete them using S3 Bucket Lifecycle rules. For the former, it's already part of the URL, we can add comments to zipfiles as an alternative way of annotating the run ID, and [S3 Batch Operations](https://aws.amazon.com/about-aws/whats-new/2018/11/s3-batch-operations/) might be a more cost-effective way to delete large numbers of tiles.

This disables setting the tags by default, and can be overridden with `--job-env-overrides` if desired.