### PR TITLE
Reduce high zoom "long tail" of jobs

### DIFF
--- a/batch-setup/make_meta_tiles.py
+++ b/batch-setup/make_meta_tiles.py
@@ -204,7 +204,7 @@ class MissingTileFinder(object):
             shutil.rmtree(tmpdir)
 
 
-def _JobSizer(object):
+class _JobSizer(object):
     def __init__(self, bucket, prefix, key_format_type):
         self.bucket = bucket
         self.prefix = prefix

--- a/batch-setup/make_meta_tiles.py
+++ b/batch-setup/make_meta_tiles.py
@@ -150,9 +150,9 @@ class MissingTileFinder(object):
 
             print("Splitting into high and low zoom lists")
 
-            # contains zooms 0 until (but not including) split zoom. anything
-            # beyond that is not needed and we just drop it.
-            missing_low = CoordSet(split_zoom - 1, drop_over_bounds=True)
+            # contains zooms 0 until group zoom. the jobs between the group
+            # zoom and RAWR zoom are merged into the parent at group zoom.
+            missing_low = CoordSet(zoom_max)
 
             # contains job coords at either zoom_max or split_zoom only.
             # zoom_max is a misnomer here, as it's always less than or equal to
@@ -163,6 +163,11 @@ class MissingTileFinder(object):
                 for line in fh:
                     c = deserialize_coord(line)
                     if c.zoom < split_zoom:
+                        # in order to not have too many jobs in the queue, we
+                        # group the low zoom jobs to the zoom_max (usually 7)
+                        if c.zoom > zoom_max:
+                            c = c.zoomTo(zoom_max).container()
+
                         missing_low[c] = True
 
                     else:

--- a/batch-setup/tileset.py
+++ b/batch-setup/tileset.py
@@ -124,17 +124,17 @@ class CoordSet(object):
         if coord.zoom > self.max_zoom and not self.drop_over_bounds:
             coord = coord.zoomTo(self.max_zoom).container()
 
-        return self.zooms.get(coord.zoom)
+        return self.zooms.get(coord.zoom), coord
 
     def __getitem__(self, coord):
-        bits = self._zoom_for(coord)
+        bits, coord = self._zoom_for(coord)
         if bits is not None:
             return bits[coord]
         else:
             raise KeyError(coord)
 
     def __setitem__(self, coord, value):
-        bits = self._zoom_for(coord)
+        bits, coord = self._zoom_for(coord)
         if bits is not None:
             bits[coord] = value
 
@@ -161,3 +161,11 @@ if __name__ == '__main__':
     c[zoom0_coord] = True
     c[zoom10_coord] = True
     assert set(c) == set([zoom0_coord, zoom10_coord])
+
+    c = CoordSet(10, min_zoom=7)
+    c[Coordinate(zoom=11, column=3, row=1)] = True
+    assert list(c) == [Coordinate(zoom=10, column=1, row=0)]
+
+    c = CoordSet(10, min_zoom=7, drop_over_bounds=True)
+    c[Coordinate(zoom=11, column=3, row=1)] = True
+    assert list(c) == []

--- a/batch-setup/tileset.py
+++ b/batch-setup/tileset.py
@@ -1,0 +1,163 @@
+from ModestMaps.Core import Coordinate
+from itertools import chain
+
+
+class BitSet(object):
+    """
+    A single-zoom set of Coordinates or, equivalently, a mapping from
+    Coordinates to booleans.
+
+    This is done in a fairly memory-efficient manner by using a single bit per
+    Coordinate and storing those in a bytearray. This means that total memory
+    usage should be roughly equal to (4 ** zoom) / 8 bytes, plus some noise for
+    pointers.
+
+    Bits can be set or cleared using a getitem/setitem interface, e.g:
+
+    >>> b = BitSet(0)
+    >>> b[Coordinate(zoom=0, column=0, row=0)] = True
+    >>> b[Coordinate(zoom=0, column=0, row=0)]
+    True
+
+    The Coordinates which are set to True can be iterated using the usual
+    idiom:
+
+    >>> b = BitSet(0)
+    >>> b[Coordinate(zoom=0, column=0, row=0)] = True
+    >>> list(b) == [Coordinate(zoom=0, column=0, row=0)]
+    True
+
+    """
+
+    def __init__(self, zoom):
+        self.zoom = zoom
+        num_tiles = 1 << (2 * zoom)
+
+        # one bit per tile takes up ceil(tiles / 8) bytes, and we might waste
+        # up to seven trailing bits.
+        num_bytes = num_tiles // 8
+        if num_tiles % 8 > 0:
+            num_bytes += 1
+
+        self.buf = bytearray(num_bytes)
+
+    def _bit_index(self, coord):
+        assert coord.zoom == self.zoom
+        bit_index = (int(coord.column) << self.zoom) + int(coord.row)
+        return (bit_index // 8, bit_index % 8)
+
+    def __getitem__(self, coord):
+        byte_index, bit_index = self._bit_index(coord)
+        byte = self.buf[byte_index]
+        return byte & (1 << bit_index) > 0
+
+    def __setitem__(self, coord, value):
+        byte_index, bit_index = self._bit_index(coord)
+        byte = self.buf[byte_index]
+        if value:
+            byte |= 1 << bit_index
+        else:
+            byte &= ~(1 << bit_index)
+        self.buf[byte_index] = byte
+
+    def __iter__(self):
+        return BitSetIterator(self)
+
+
+class BitSetIterator(object):
+    """
+    Helper class to iterate over the True bits in a BitSet, yielding their
+    Coordinates.
+    """
+
+    def __init__(self, container):
+        self.container = container
+        self.index = 0
+        self.max_index = 1 << (2 * self.container.zoom)
+
+    def __iter__(self):
+        return self
+
+    def next(self):
+        while True:
+            if self.index >= self.max_index:
+                raise StopIteration()
+
+            index = self.index
+            self.index += 1
+
+            byte = self.container.buf[index // 8]
+            if byte & (1 << (index % 8)) > 0:
+                coord = Coordinate(
+                    zoom=self.container.zoom,
+                    column=(index >> self.container.zoom),
+                    row=(index & ((1 << self.container.zoom) - 1)))
+                return coord
+
+
+class CoordSet(object):
+    """
+    A set of Coordinates, implemented as a mapping of Coordinate to True/False.
+
+    Can contain Coordinates over range of zooms, and modify Coordinates with a
+    zoom greater than the maximum to be in range.
+    """
+
+    def __init__(self, max_zoom, min_zoom=0, drop_over_bounds=False):
+        """
+        Construct a set of Coordinates covering max_zoom through min_zoom,
+        inclusive.
+
+        Coordinates under the min_zoom will be dropped. Coordinates over the
+        max zoom will be moved into range if drop_over_bounds is False, or
+        dropped if it is True.
+        """
+        self.min_zoom = min_zoom
+        self.max_zoom = max_zoom
+        self.drop_over_bounds = drop_over_bounds
+
+        self.zooms = {}
+        for z in xrange(min_zoom, max_zoom + 1):
+            self.zooms[z] = BitSet(z)
+
+    def _zoom_for(self, coord):
+        if coord.zoom > self.max_zoom and not self.drop_over_bounds:
+            coord = coord.zoomTo(self.max_zoom).container()
+
+        return self.zooms.get(coord.zoom)
+
+    def __getitem__(self, coord):
+        bits = self._zoom_for(coord)
+        if bits is not None:
+            return bits[coord]
+        else:
+            raise KeyError(coord)
+
+    def __setitem__(self, coord, value):
+        bits = self._zoom_for(coord)
+        if bits is not None:
+            bits[coord] = value
+
+    def __iter__(self):
+        iters = [z.__iter__() for z in self.zooms.values()]
+        return chain(*iters)
+
+
+if __name__ == '__main__':
+    b = BitSet(0)
+    assert list(b) == []
+    zoom0_coord = Coordinate(zoom=0, column=0, row=0)
+    b[zoom0_coord] = True
+    assert list(b) == [zoom0_coord]
+
+    b = BitSet(10)
+    assert list(b) == []
+    zoom10_coord = Coordinate(zoom=10, column=123, row=456)
+    b[zoom10_coord] = True
+    assert list(b) == [zoom10_coord]
+
+    c = CoordSet(10)
+    assert list(c) == []
+    c[zoom0_coord] = True
+    c[zoom10_coord] = True
+    assert set(c) == set([zoom0_coord, zoom10_coord])


### PR DESCRIPTION
When we're processing jobs in AWS Batch, there's always a "long tail" of jobs which take much longer than others to complete. This is partly because we group 64 items of work at zoom 10 together into one Batch job at zoom 7, and these aren't able to take advantage of any concurrency. The grouping at zoom 7 is useful to reduce overall job count and we don't want to get rid of it entirely. Instead, if we can detect these "big" jobs and submit only the "big" items of work as individual jobs, while still grouping the "small" items together, then we'll be better able to use the number of processors available to us.

This PR does that, by:

1. Finding the set of zoom 7 groups of RAWR tiles where the sum of the sizes of the RAWR tiles is large (the `--size-threshold` CLI argument, defaults to 350MB) and storing that in a "big jobs" set of coordinates.
2. When splitting the list of missing coordinates into high and low zoom sets, checking to see if the high zoom coordinate is a descendant of a zoom 7 coordinate in the "big jobs" set. If it is, then enqueue it as a zoom 10 job, otherwise a zoom 7 job.

The high, low and "big jobs" sets are stored as `CoordSet`, a new class for hopefully efficiently managing very large sets of tile coordinates without running out of memory.

Connects to #17.