### PR TITLE
Allow TPS instance to read RAWR tiles.

### DIFF
--- a/batch-setup/cron.py
+++ b/batch-setup/cron.py
@@ -156,6 +156,7 @@ def create_tps_profile(iam, profile_name, locations):
                 Resource=[
                     'arn:aws:s3:::' + locations.missing.name,
                     'arn:aws:s3:::' + locations.assets.name,
+                    'arn:aws:s3:::' + locations.rawr.name,
                 ],
             ),
             dict(
@@ -167,6 +168,7 @@ def create_tps_profile(iam, profile_name, locations):
                     'arn:aws:s3:::' + locations.assets.name + '/tileops/*',
                     'arn:aws:s3:::' + locations.assets.name + assets_path,
                     'arn:aws:s3:::' + locations.missing.name + '/*',
+                    'arn:aws:s3:::' + locations.rawr.name + '/*',
                 ],
             ),
         ],


### PR DESCRIPTION
[PR #47](https://github.com/tilezen/tileops/pull/47) added a feature to vary Batch job sizes according to the size of RAWR tiles, but missed the permission to read the RAWR tile S3 bucket, meaning all the requests failed.