### PR TITLE
Shut down databases after low zoom rendering

### DIFF
--- a/batch-setup/make_meta_tiles.py
+++ b/batch-setup/make_meta_tiles.py
@@ -304,6 +304,9 @@ def enqueue_tiles(config_file, tile_list_file, check_metatile_exists):
     tilequeue_batch_enqueue(cfg, args)
 
 
+# adaptor class for MissingTiles to see just the high zoom parts, this is used
+# along with the LowZoomLense to loop over missing tiles generically but
+# separately.
 class HighZoomLense(object):
     def __init__(self, config):
         self.config = config
@@ -322,6 +325,9 @@ class LowZoomLense(object):
         return missing.low_zoom_file
 
 
+# abstracts away the logic for a re-rendering loop, splitting between high and
+# low zoom tiles and stopping if all the tiles aren't rendered within a
+# certain number of retries.
 class TileRenderer(object):
 
     def __init__(self, tile_finder, big_jobs, split_zoom, zoom_max):

--- a/batch-setup/make_meta_tiles.py
+++ b/batch-setup/make_meta_tiles.py
@@ -193,23 +193,19 @@ def enqueue_tiles(config_file, tile_list_file, check_metatile_exists):
 class HighZoomLense(object):
     def __init__(self, config):
         self.config = config
+        self.description = "high zoom tiles"
 
     def missing_file(self, missing):
         return missing.high_zoom_file
-
-    def description(self):
-        return "high zoom tiles"
 
 
 class LowZoomLense(object):
     def __init__(self, config):
         self.config = config
+        self.description = "low zoom tiles"
 
     def missing_file(self, missing):
         return missing.low_zoom_file
-
-    def description(self):
-        return "low zoom tiles"
 
 
 class TileRenderer(object):

--- a/batch-setup/make_meta_tiles.py
+++ b/batch-setup/make_meta_tiles.py
@@ -241,8 +241,9 @@ class TileRenderer(object):
             with self._missing() as missing:
                 missing_tile_file = lense.missing_file(missing)
                 count = wc_line(missing_tile_file)
-                print("FAILED! %d %s still missing after %d tries"
-                      % (count, lense.description, num_retries))
+                raise RuntimeError(
+                    "FAILED! %d %s still missing after %d tries"
+                    % (count, lense.description, num_retries))
 
 
 if __name__ == '__main__':

--- a/batch-setup/make_meta_tiles.py
+++ b/batch-setup/make_meta_tiles.py
@@ -191,6 +191,9 @@ def enqueue_tiles(config_file, tile_list_file, check_metatile_exists):
 
 
 class HighZoomLense(object):
+    def __init__(self, config):
+        self.config = config
+
     def missing_file(self, missing):
         return missing.high_zoom_file
 
@@ -199,6 +202,9 @@ class HighZoomLense(object):
 
 
 class LowZoomLense(object):
+    def __init__(self, config):
+        self.config = config
+
     def missing_file(self, missing):
         return missing.low_zoom_file
 
@@ -306,9 +312,9 @@ if __name__ == '__main__':
 
     tile_renderer = TileRenderer(tile_finder, split_zoom, zoom_max)
 
-    tile_renderer.render(args.retries, LowZoomLense())
+    tile_renderer.render(args.retries, LowZoomLense(args.low_zoom_config))
 
     # turn off databases by saying we want to ensure that zero are running.
     ensure_dbs(args.run_id, 0)
 
-    tile_renderer.render(args.retries, HighZoomLense())
+    tile_renderer.render(args.retries, HighZoomLense(args.high_zoom_config))


### PR DESCRIPTION
Rendering high zoom tiles is done entirely from RAWR tiles, and the databases are not used at all. Due to their larger number and long tail of complex long-running jobs, this means we're keeping a lot of expensive databases running for no reason.

Splitting the low zoom (DB) from the high zoom (RAWR) potentially is less efficient, as the RAWR and DB jobs can't mix together and make full use of CPU and network resources. This loss of efficiency is probably several orders of magnitude less than leaving ten databases idle for a day or two!

This patch abstracts the rendering loop away from high and low zoom tiles, and inserts a command to shut down the databases between the two invocations.

Connects to #15.