### PR TITLE
Bump PyPROJ version to v2.1.0 for new Transformer interface.

### DIFF
--- a/docker/meta-batch/requirements.txt
+++ b/docker/meta-batch/requirements.txt
@@ -11,7 +11,7 @@ protobuf==3.4.0
 psycopg2==2.7.3.2
 pyclipper==1.0.6
 pycountry==17.9.23
-pyproj==1.9.5.1
+pyproj==2.1.0
 python-dateutil==2.6.1
 PyYAML==4.2b4
 redis==2.10.6

--- a/docker/meta-low-zoom-batch/requirements.txt
+++ b/docker/meta-low-zoom-batch/requirements.txt
@@ -11,7 +11,7 @@ protobuf==3.4.0
 psycopg2==2.7.3.2
 pyclipper==1.0.6
 pycountry==17.9.23
-pyproj==1.9.5.1
+pyproj==2.1.0
 python-dateutil==2.6.1
 PyYAML==4.2b4
 redis==2.10.6

--- a/docker/rawr-batch/requirements.txt
+++ b/docker/rawr-batch/requirements.txt
@@ -11,7 +11,7 @@ protobuf==3.4.0
 psycopg2==2.7.3.2
 pyclipper==1.0.6
 pycountry==17.9.23
-pyproj==1.9.5.1
+pyproj==2.1.0
 python-dateutil==2.6.1
 PyYAML==4.2b4
 redis==2.10.6

--- a/utils/setup.sh
+++ b/utils/setup.sh
@@ -123,7 +123,7 @@ protobuf==3.4.0
 psycopg2==2.7.3.2
 pyclipper==1.0.6
 pycountry==17.9.23
-pyproj==1.9.5.1
+pyproj==2.1.0
 python-dateutil==2.6.1
 redis==2.10.6
 requests==2.20.0


### PR DESCRIPTION
Bump version of PyPROJ in `requirements.txt` files used in Docker and TPS provisioning script to v2.1.0, which provides the `Transformer` interface we'll be using in `tilequeue` if https://github.com/tilezen/tilequeue/pull/371 gets merged.
