### PR TITLE
Update osmdata source, now hosted at osmdata.openstreetmap.de.

### DIFF
--- a/docker/meta-batch/config.yaml
+++ b/docker/meta-batch/config.yaml
@@ -41,7 +41,7 @@ rawr:
       planet_osm_ways: *osm
       planet_osm_rels: *osm
       wof_neighbourhood: { name: wof, value: whosonfirst.org }
-      water_polygons: &osmdata { name: shp, value: openstreetmapdata.com }
+      water_polygons: &osmdata { name: shp, value: osmdata.openstreetmap.de }
       land_polygons: *osmdata
       ne_10m_urban_areas: { name: ne, value: naturalearthdata.com }
       admin_areas: *osm

--- a/docker/rawr-batch/config.yaml
+++ b/docker/rawr-batch/config.yaml
@@ -21,7 +21,7 @@ rawr:
       planet_osm_ways: *osm
       planet_osm_rels: *osm
       wof_neighbourhood: { name: wof, value: whosonfirst.org }
-      water_polygons: &osmdata { name: shp, value: openstreetmapdata.com }
+      water_polygons: &osmdata { name: shp, value: osmdata.openstreetmap.de }
       land_polygons: *osmdata
       ne_10m_urban_areas: { name: ne, value: naturalearthdata.com }
       admin_areas: *osm


### PR DESCRIPTION
Update configuration files used in AWS Batch builds for RAWR tiles and high-zoom metatiles to use new source for osmdata land and water polygons.

Connects to tilezen/vector-datasource#1855.
