### PR TITLE
Allow specifying a URL for planet instead of assuming the osm-pds S3

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ The process has to go through three stages:
 2. Using replicas started from the snapshot to "render" RAWR tiles using AWS Batch.
 3. Using the replicas and RAWR tiles to render meta tiles, suitable for use with Tapalcatl(-py).
 
-The first thing to do, locally, is make sure that the Go commands have been built. See [the Go README](go/README.md) for details on how to do this. The Python environment will also need to be set up, see [the Python README](doc/import/README.md). You will also need to have the `raw_tiles`, `tilequeue` and `vector-datasource` projects checked out as siblings to the `tileops` directory, i.e: accessible as `../raw_tiles/` and so forth from this README.
+The first thing to do, locally, is make sure that the Go commands have been built. See [the Go README](go/README.md) for details on how to do this. The Python environment will also need to be set up, see [the Python README](doc/import/README.md). You will also need to have the [`raw_tiles`](https://github.com/tilezen/raw_tiles), [`tilequeue`](https://github.com/tilezen/tilequeue) and [`vector-datasource`](https://github.com/tilezen/vector-datasource) projects checked out as siblings to the `tileops` directory, i.e: accessible as `../raw_tiles/` and so forth from this README.
 
 Rendering meta tiles can be done with the following commands:
 

--- a/import/import.py
+++ b/import/import.py
@@ -77,7 +77,8 @@ if args.planet_url:
 
     print("Downloading planet from %s" % planet_url)
 
-    planet_md5_url = args.planet_md5_url
+    # set to empty string so it doesn't get serialized as 'None'
+    planet_md5_url = args.planet_md5_url or ""
 else:
     if args.date is None:
         planet_date = osm.latest_planet_date()

--- a/import/import.py
+++ b/import/import.py
@@ -1,3 +1,4 @@
+from urllib.parse import urlparse
 import argparse
 import database
 import datetime
@@ -43,6 +44,13 @@ parser = argparse.ArgumentParser(
     description='Automated Tilezen database import')
 parser.add_argument('--date', help='Date of the data (i.e: OSM planet file) '
                     'to use. Defaults to the latest available. YYYY-MM-DD.')
+parser.add_argument('--planet-url', help='Instead of downloading the planet '
+                    'file at a given --date, download it from this URL. '
+                    'Requires setting --run-id.')
+parser.add_argument('--planet-md5-url', help='When using --planet-url, '
+                    'optionally set this to download the MD5 checksum of '
+                    'the file at --planet-url to check the md5sum. Leave '
+                    'this unset to skip performing the md5sum.')
 parser.add_argument('bucket', help="S3 Bucket to store flat nodes file in.")
 parser.add_argument('region', help="AWS Region of the bucket to store "
                     "flat nodes.")
@@ -61,14 +69,36 @@ parser.add_argument('--run-id', help='Distinctive run ID to give to '
 
 args = parser.parse_args()
 
-if args.date is None:
-    planet_date = osm.latest_planet_date()
-    print("Latest planet date is: %s" % planet_date.strftime('%Y-%m-%d'))
-else:
-    planet_date = datetime.datetime.strptime(args.date, '%Y-%m-%d').date()
+if args.planet_url:
+    planet_url = args.planet_url
 
-run_id = args.run_id or planet_date.strftime('%y%m%d')
+    assert args.run_id, '--planet-url requires --run-id'
+    run_id = args.run_id
+
+    print("Downloading planet from %s" % planet_url)
+
+    planet_md5_url = args.planet_md5_url
+else:
+    if args.date is None:
+        planet_date = osm.latest_planet_date()
+        print("Latest planet date is: %s" % planet_date.strftime('%Y-%m-%d'))
+    else:
+        planet_date = datetime.datetime.strptime(args.date, '%Y-%m-%d').date()
+
+    planet_url = "http://s3.amazonaws.com/osm-pds/{planet_year}/planet-{planet_date}.osm.pbf".format(
+        planet_year=planet_date.year,
+        planet_date=planet_date.strftime('%y%m%d'),
+    )
+    planet_md5_url = "http://s3.amazonaws.com/osm-pds/{planet_year}/planet-{planet_date}.osm.pbf.md5".format(
+        planet_year=planet_date.year,
+        planet_date=planet_date.strftime('%y%m%d'),
+    )
+
+    run_id = args.run_id or planet_date.strftime('%y%m%d')
 assert_run_id_format(run_id)
+
+# calculate the filename to use when downloading the planet file
+planet_file = urlparse(planet_url).path.rsplit("/", 1)[-1]
 
 # if there's a snapshot already, then exit.
 assert_no_snapshot(run_id)
@@ -89,7 +119,7 @@ else:
 
 
 osm2pgsql.ensure_import(
-    run_id, planet_date, db, getattr(args, 'iam-instance-profile'),
+    run_id, planet_url, planet_md5_url, planet_file, db, getattr(args, 'iam-instance-profile'),
     args.bucket, args.region, ip_addr, args.vector_datasource_version)
 
 database.take_snapshot_and_shutdown(db, run_id)

--- a/import/import_planet.sh
+++ b/import/import_planet.sh
@@ -87,7 +87,7 @@ if [[ ! -f "planet/${PLANET_FILE}" ]]; then
     cd planet/
     wget -q "${PLANET_URL}"
 
-    if [[ -z "${PLANET_MD5_URL}" ]]; then
+    if [[ -n "${PLANET_MD5_URL}" ]]; then
         wget -q "${PLANET_MD5_URL}"
     fi
 

--- a/import/osm2pgsql.py
+++ b/import/osm2pgsql.py
@@ -1,5 +1,5 @@
 import boto3
-from StringIO import StringIO
+from io import StringIO
 from paramiko.rsakey import RSAKey
 from botocore.exceptions import ClientError
 from contextlib import contextmanager
@@ -305,7 +305,7 @@ class Instance(object):
 
                 yield ssh
 
-        except StandardError as e:
+        except Exception as e:
             raise RuntimeError("ERROR: %s (on ubuntu@%s)" % (e, ip))
 
         finally:
@@ -430,8 +430,9 @@ def shutdown_and_cleanup(ec2, import_instance_id, run_id, ip_addr):
 
 
 def ensure_import(
-        run_id, planet_date, db, iam_instance_profile, bucket, aws_region,
-        ip_addr, vector_datasource_version='master'):
+        run_id, planet_url, planet_md5_url, planet_file,
+        db, iam_instance_profile, bucket, aws_region, ip_addr,
+        vector_datasource_version='master'):
     ec2 = boto3.client('ec2')
 
     # is there already an import instance running?
@@ -498,8 +499,9 @@ def ensure_import(
         # run the script on the host
         instance.repeatedly(
             'import_planet.sh',
-            planet_year=planet_date.year,
-            planet_date=planet_date.strftime('%y%m%d'),
+            planet_url=planet_url,
+            planet_md5_url=planet_md5_url,
+            planet_file=planet_file,
             db_pass=db.password,
             db_host=db.host,
             db_port=db.port,


### PR DESCRIPTION
Adds a feature to specify a URL to download from instead of calculating the URL to the `osm-pds` bucket using the "planet date" value. Specifying the `--planet-url` option also makes MD5 checksumming optional. Add the `--planet-md5-url` argument to download and use that file to checksum the planet downloaded with `--planet-url`.