### PR TITLE
Remove HTMLParser dependency by parsing HTTP redirect on planet-latest

### DIFF
--- a/import/osm.py
+++ b/import/osm.py
@@ -1,31 +1,24 @@
 import requests
-from HTMLParser import HTMLParser
 import re
 from datetime import datetime
 
 
-planet_file_pattern = re.compile('^planet-([0-9]{6}).osm.pbf$')
-
-
-class LatestLinkFinder(HTMLParser, object):
-    def __init__(self):
-        super(LatestLinkFinder, self).__init__()
-        self.date = None
-
-    def handle_starttag(self, tag, attrs):
-        dict_attrs = dict(attrs)
-        if tag == 'a' and 'href' in dict_attrs:
-            match = planet_file_pattern.match(dict_attrs['href'])
-            if match:
-                date = datetime.strptime(match.groups()[0], '%y%m%d').date()
-                if self.date is None or date > self.date:
-                    self.date = date
+planet_file_pattern = re.compile('^https://planet.openstreetmap.org/pbf/planet-([0-9]{6}).osm.pbf$')
 
 
 def latest_planet_date():
-    link_finder = LatestLinkFinder()
-    req = requests.get('https://planet.openstreetmap.org/pbf/')
-    assert req.status_code == 200
-    link_finder.feed(req.text)
-    assert link_finder.date
-    return link_finder.date
+    # Fetch the latest planet redirect
+    req = requests.get('https://planet.openstreetmap.org/pbf/planet-latest.osm.pbf', allow_redirects=False)
+    assert req.status_code == 302
+    assert req.next
+    assert req.next.url
+
+    # Match the redirect URL to extract the date
+    match = planet_file_pattern.match(req.next.url)
+    assert match
+
+    # Parse the date and return it
+    date = datetime.strptime(match.groups(1), '%y%m%d').date()
+    assert date
+
+    return date


### PR DESCRIPTION
Rather than fixing the `HTMLParser` dependency, I switched to parsing the redirect URL for planet-latest.