### PR TITLE
Log resource stats for each run

### DIFF
--- a/batch-setup/batch.py
+++ b/batch-setup/batch.py
@@ -113,7 +113,8 @@ def cmd_for_image(name, region):
                '--run_id', 'Ref::run_id']
 
     elif name == 'meta-batch':
-        cmd = ['tilequeue', 'meta-tile',
+        cmd = ['/usr/bin/time', '-f', '"{\\"max_resident_kb\\": %M, \\"cpu_percent\\": \\"%P\\", \\"wall_time_seconds\\": %e}\\"',
+               'tilequeue', 'meta-tile',
                '--config', '/etc/tilequeue/config.yaml',
                '--tile', 'Ref::tile',
                '--run_id', 'Ref::run_id']

--- a/docker/meta-batch/Dockerfile
+++ b/docker/meta-batch/Dockerfile
@@ -1,7 +1,7 @@
 FROM python:2
 
 RUN apt-get -y update \
- && apt-get -y install libgeos-dev libboost-python-dev \
+ && apt-get -y install libgeos-dev libboost-python-dev time \
  && rm -rf /var/lib/apt/lists/*
 
 COPY raw_tiles /usr/src/raw_tiles


### PR DESCRIPTION
* Added `/usr/bin/time` to the docker container and 
* wrap the meta-batch gen command in `time` so we can report some stats on each run
* I validated this formatting works using a modified job from the last global build.  Here's what it logs:
![image](https://user-images.githubusercontent.com/879175/113330943-2c5dd100-92d4-11eb-9471-b816d3e5e929.png)
