### PR TITLE
Reducing concurrency

### DIFF
--- a/go/cmd/tz-missing-meta-tiles-write/missing-meta-tiles-write.go
+++ b/go/cmd/tz-missing-meta-tiles-write/missing-meta-tiles-write.go
@@ -159,7 +159,7 @@ func main() {
 	flag.StringVar(&destBucket, "dest-bucket", "", "dest s3 bucket to write tiles")
 	flag.StringVar(&destDatePrefix, "dest-date-prefix", "", "dest date prefix to write tiles found")
 	flag.StringVar(&hexPrefix, "hex-prefix", "", "hex prefix for job, must be 3 lowercase hexadecimal characters")
-	flag.UintVar(&concurrency, "concurrency", 16, "number of goroutines listing bucket per hash prefix")
+	flag.UintVar(&concurrency, "concurrency", 4, "number of goroutines listing bucket per hash prefix")
 	flag.StringVar(&region, "region", "us-east-1", "region")
 	flag.StringVar(&keyFormatTypeStr, "key-format-type", "", "Either 'prefix-hash' or 'hash-prefix' to control the order of the date prefix and hash in the src S3 key.")
 	flag.BoolVar(&allBuckets, "all-buckets", false, "If true, check all buckets in list, not just the last one.")


### PR DESCRIPTION
This was being heavily throttled by s3, so much so that we were reporting tiles as missing because the searches for those got throttled too many times.  It actually appears to be as fast, possibly faster, with less goroutines due to the reduced thrashing.