### PR TITLE
add implementation of missing tiles generator

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -9,3 +9,8 @@ paramiko = "*"
 requests = "*"
 urllib3 = ">=1.24.2"
 pyyaml = "*"
+modestmaps = "*"
+mercantile = "*"
+
+[dev-packages]
+pytest = "*"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "bd779a503e17b9f4dac220458139c24df2f316116dcbc71aa30e653fad9c41ab"
+            "sha256": "0301e3031cd9776631604e33f2b1810187ddc3f64ca2692a48cf88c10bc4eddb"
         },
         "pipfile-spec": 6,
         "requires": {},
@@ -100,6 +100,14 @@
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
             "version": "==4.0.0"
         },
+        "click": {
+            "hashes": [
+                "sha256:d2b5255c7c6349bc1bd1e59e08cd12acbbd63ce649f2588755783aa94dfb6b1a",
+                "sha256:dacca89f4bfadd5de3d7489b7c8a566eee0d3676333fbb50030263894c38c0dc"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
+            "version": "==7.1.2"
+        },
         "cryptography": {
             "hashes": [
                 "sha256:0f1212a66329c80d68aeeb39b8a16d54ef57071bf22ff4e521657b27372e327d",
@@ -133,6 +141,21 @@
             ],
             "markers": "python_version >= '2.6' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==0.10.0"
+        },
+        "mercantile": {
+            "hashes": [
+                "sha256:30f457a73ee88261aab787b7069d85961a5703bb09dc57a170190bc042cd023f",
+                "sha256:fa3c6db15daffd58454ac198b31887519a19caccee3f9d63d17ae7ff61b3b56b"
+            ],
+            "index": "pypi",
+            "version": "==1.2.1"
+        },
+        "modestmaps": {
+            "hashes": [
+                "sha256:698442a170f02923f8ea55f18526b56c17178162e44304f896a8a5fd65ab4457"
+            ],
+            "index": "pypi",
+            "version": "==1.4.7"
         },
         "paramiko": {
             "hashes": [
@@ -249,5 +272,69 @@
             "version": "==1.26.4"
         }
     },
-    "develop": {}
+    "develop": {
+        "attrs": {
+            "hashes": [
+                "sha256:149e90d6d8ac20db7a955ad60cf0e6881a3f20d37096140088356da6c716b0b1",
+                "sha256:ef6aaac3ca6cd92904cdd0d83f629a15f18053ec84e6432106f7a4d04ae4f5fb"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
+            "version": "==21.2.0"
+        },
+        "iniconfig": {
+            "hashes": [
+                "sha256:011e24c64b7f47f6ebd835bb12a743f2fbe9a26d4cecaa7f53bc4f35ee9da8b3",
+                "sha256:bc3af051d7d14b2ee5ef9969666def0cd1a000e121eaea580d4a313df4b37f32"
+            ],
+            "version": "==1.1.1"
+        },
+        "packaging": {
+            "hashes": [
+                "sha256:5b327ac1320dc863dca72f4514ecc086f31186744b84a230374cc1fd776feae5",
+                "sha256:67714da7f7bc052e064859c05c595155bd1ee9f69f76557e21f051443c20947a"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "version": "==20.9"
+        },
+        "pluggy": {
+            "hashes": [
+                "sha256:15b2acde666561e1298d71b523007ed7364de07029219b604cf808bfa1c765b0",
+                "sha256:966c145cd83c96502c3c3868f50408687b38434af77734af1e9ca461a4081d2d"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "version": "==0.13.1"
+        },
+        "py": {
+            "hashes": [
+                "sha256:21b81bda15b66ef5e1a777a21c4dcd9c20ad3efd0b3f817e7a809035269e1bd3",
+                "sha256:3b80836aa6d1feeaa108e046da6423ab8f6ceda6468545ae8d02d9d58d18818a"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "version": "==1.10.0"
+        },
+        "pyparsing": {
+            "hashes": [
+                "sha256:c203ec8783bf771a155b207279b9bccb8dea02d8f0c9e5f8ead507bc3246ecc1",
+                "sha256:ef9d7589ef3c200abe66653d3f1ab1033c3c419ae9b9bdb1240a85b024efc88b"
+            ],
+            "markers": "python_version >= '2.6' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "version": "==2.4.7"
+        },
+        "pytest": {
+            "hashes": [
+                "sha256:50bcad0a0b9c5a72c8e4e7c9855a3ad496ca6a881a3641b4260605450772c54b",
+                "sha256:91ef2131a9bd6be8f76f1f08eac5c5317221d6ad1e143ae03894b862e8976890"
+            ],
+            "index": "pypi",
+            "version": "==6.2.4"
+        },
+        "toml": {
+            "hashes": [
+                "sha256:806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b",
+                "sha256:b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f"
+            ],
+            "markers": "python_version >= '2.6' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "version": "==0.10.2"
+        }
+    }
 }

--- a/batch-setup/make_meta_tiles.py
+++ b/batch-setup/make_meta_tiles.py
@@ -136,7 +136,6 @@ class MissingTileFinder(object):
                '-max-zoom', str(self.max_zoom),
                stdout=filename)
 
-    @contextmanager
     def generate_missing_tiles_coords(self, try_generator=False):
         # type: () -> List[Coordinate]
         """ generate the missing tiles coordinates for low/high-zoom
@@ -193,23 +192,23 @@ class MissingTileFinder(object):
             # split zoom?
             missing_high = CoordSet(min_zoom=zoom_max, max_zoom=split_zoom)
 
-            with self.generate_missing_tiles_coords(try_generator) as coords:
-                for c in coords:
-                    if c.zoom < split_zoom:  # 10
-                        # in order to not have too many jobs in the queue, we
-                        # group the low zoom jobs to the zoom_max (usually 7)
-                        if c.zoom > zoom_max:  # 7
-                            c = c.zoomTo(zoom_max).container()
-                        missing_low[c] = True
-                    else:
-                        # if the group of jobs at zoom_max would be too big
-                        # (according to big_jobs[]) then enqueue the original
-                        # coordinate. this is to prevent a "long tail" of huge
-                        # job groups.
-                        job_coord = c.zoomTo(zoom_max).container()  # 7
-                        if not big_jobs[job_coord]:
-                            c = job_coord
-                        missing_high[c] = True
+            coords = self.generate_missing_tiles_coords(try_generator)
+            for c in coords:
+                if c.zoom < split_zoom:  # 10
+                    # in order to not have too many jobs in the queue, we
+                    # group the low zoom jobs to the zoom_max (usually 7)
+                    if c.zoom > zoom_max:  # 7
+                        c = c.zoomTo(zoom_max).container()
+                    missing_low[c] = True
+                else:
+                    # if the group of jobs at zoom_max would be too big
+                    # (according to big_jobs[]) then enqueue the original
+                    # coordinate. this is to prevent a "long tail" of huge
+                    # job groups.
+                    job_coord = c.zoomTo(zoom_max).container()  # 7
+                    if not big_jobs[job_coord]:
+                        c = job_coord
+                    missing_high[c] = True
 
             with open(missing_low_file, 'w') as fh:
                 for coord in missing_low:

--- a/batch-setup/make_meta_tiles.py
+++ b/batch-setup/make_meta_tiles.py
@@ -20,7 +20,7 @@ from tileset import CoordSet
 from tilequeue.store import make_s3_tile_key_generator
 from ModestMaps.Core import Coordinate
 from multiprocessing import Pool
-from typing import Iterator
+#from typing import Iterator
 
 
 MissingTiles = namedtuple('MissingTiles', 'low_zoom_file high_zoom_file')

--- a/batch-setup/make_meta_tiles.py
+++ b/batch-setup/make_meta_tiles.py
@@ -20,7 +20,6 @@ from tileset import CoordSet
 from tilequeue.store import make_s3_tile_key_generator
 from ModestMaps.Core import Coordinate
 from multiprocessing import Pool
-from typing import NamedTuple
 from typing import Iterator
 
 
@@ -31,7 +30,7 @@ class MissingTileFinder(object):
     """
     Finds tiles missing from an S3 bucket and provides convenience methods to
     navigate them.
-    If tiles_generator is provided, it will use that to generate missing tiles.
+    If tiles_coords_generator is provided, it will use that to generate missing tiles.
     """
 
     def __init__(self, missing_bucket, tile_bucket, src_date_prefix,
@@ -365,13 +364,13 @@ class LowZoomLense(object):
 class TileRenderer(object):
 
     def __init__(self, tile_finder, big_jobs, split_zoom, zoom_max,
-                 allowed_missing_tiles=0, tiles_generator=None):
+                 allowed_missing_tiles=0, tiles_coords_generator=None):
         self.tile_finder = tile_finder
         self.big_jobs = big_jobs
         self.split_zoom = split_zoom
         self.zoom_max = zoom_max
         self.allowed_missing_tiles = allowed_missing_tiles
-        self.tiles_generator = tiles_generator
+        self.tiles_coords_generator = tiles_coords_generator
 
     def _missing(self):
         return self.tile_finder.missing_tiles_split(

--- a/batch-setup/make_meta_tiles.py
+++ b/batch-setup/make_meta_tiles.py
@@ -172,7 +172,6 @@ class MissingTileFinder(object):
         at zoom_max.
         """
 
-        self.run_batch_job()
         tmpdir = tempfile.mkdtemp()
         try:
             missing_low_file = os.path.join(tmpdir, 'missing.low.txt')

--- a/batch-setup/make_meta_tiles.py
+++ b/batch-setup/make_meta_tiles.py
@@ -11,7 +11,7 @@ import os
 import sys
 import shutil
 import tempfile
-from utils.tiles import BoundingBoxTilesCoordinateGenerator
+from utils.tiles import BoundingBoxTileCoordinatesGenerator
 from tilequeue.tile import metatile_zoom_from_size
 from rds import ensure_dbs
 from tilequeue.tile import deserialize_coord
@@ -493,7 +493,7 @@ if __name__ == '__main__':
         min_x, min_y, max_x, max_y = list(map(float, bboxes))
         assert min_x < max_x, 'Invalid bbox. X: {} not less than {}'.format(min_x, max_x)
         assert min_y < max_y, 'Invalid bbox. Y: {} not less than {}'.format(min_y, max_y)
-        generator = BoundingBoxTilesCoordinateGenerator(min_x=min_x,
+        generator = BoundingBoxTileCoordinatesGenerator(min_x=min_x,
                                                         min_y=min_y,
                                                         max_x=max_x,
                                                         max_y=max_y)

--- a/batch-setup/make_meta_tiles.py
+++ b/batch-setup/make_meta_tiles.py
@@ -460,8 +460,8 @@ if __name__ == '__main__':
                         'to continue the build process.')
     parser.add_argument('--use-tile-coords-generator', type=lambda x: bool(strtobool(x)), nargs='?',
                         const=True, default=False)
-    parser.add_argument('--tile-coords-generator-bbox', help="Comma separated coordinates of a bounding box "
-                                                             "min_x, min_y, max_x, max_y")
+    parser.add_argument('--tile-coords-generator-bbox', type=str,
+                        help="Comma separated coordinates of a bounding box min_x, min_y, max_x, max_y")
 
     args = parser.parse_args()
     assert_run_id_format(args.run_id)

--- a/batch-setup/make_meta_tiles.py
+++ b/batch-setup/make_meta_tiles.py
@@ -458,12 +458,10 @@ if __name__ == '__main__':
     parser.add_argument('--allowed-missing-tiles', default=2, type=int,
                         help='The maximum number of missing metatiles allowed '
                         'to continue the build process.')
-    parser.add_argument('--use-tiles-coords-generator', type=lambda x: bool(strtobool(x)), nargs='?',
+    parser.add_argument('--use-tile-coords-generator', type=lambda x: bool(strtobool(x)), nargs='?',
                         const=True, default=False)
-    parser.add_argument('--coords-generator-bbox-west', type=float, help="west longitude of bounding box to build")
-    parser.add_argument('--coords-generator-bbox-south', type=float, help="south latitude of bounding box to build")
-    parser.add_argument('--coords-generator-bbox-east', type=float, help="east longitude of bounding box to build")
-    parser.add_argument('--coords-generator-bbox-north', type=float, help="north latitude of bounding box to build")
+    parser.add_argument('--tile-coords-generator-bbox', help="Comma separated coordinates of a bounding box "
+                                                             "min_x, min_y, max_x, max_y")
 
     args = parser.parse_args()
     assert_run_id_format(args.run_id)
@@ -488,25 +486,18 @@ if __name__ == '__main__':
     assert args.metatile_size < 100
     metatile_max_zoom = 16 - metatile_zoom_from_size(args.metatile_size)
 
-    bbox_west = -181
-    bbox_south = -181
-    bbox_east = -181
-    bbox_north = -181
     generator = None
     if args.use_tile_coords_generator:
-        if args.coords_generator_bbox_west is None or args.coords_generator_bbox_south is None or \
-                args.coords_generator_bbox_east is None or args.coords_generator_bbox_north is None:
-            print("not all borders of the bounding box are provided")
-            sys.exit(1)
-        bbox_west = args.coords_generator_bbox_west
-        bbox_south = args.coords_generator_bbox_south
-        bbox_east = args.coords_generator_bbox_east
-        bbox_north = args.coords_generator_bbox_north
-
-        generator = BoundingBoxTilesCoordinateGenerator(west=bbox_west,
-                                                        south=bbox_south,
-                                                        east=bbox_east,
-                                                        north=bbox_north)
+        bboxes = args.tile_coords_generator_bbox.split(',')
+        assert len(bboxes) == 4, 'Seed config: custom bbox {} does not have exactly four elements!'.format(bboxes)
+        min_x, min_y, max_x, max_y = list(map(float, bboxes))
+        assert min_x < max_x, 'Invalid bbox. X: {} not less than {}'.format(min_x, max_x)
+        assert min_y < max_y, 'Invalid bbox. Y: {} not less than {}'.format(min_y, max_y)
+        generator = BoundingBoxTilesCoordinateGenerator(min_x=min_x,
+                                                        min_y=min_y,
+                                                        max_x=max_x,
+                                                        max_y=max_y)
+        print("[make_meta_tiles] Rebuild using bbox: " + args.tile_coords_generator_bbox)
 
     tile_finder = MissingTileFinder(
         buckets.missing, buckets.meta, date_prefix, missing_bucket_date_prefix,

--- a/batch-setup/make_meta_tiles.py
+++ b/batch-setup/make_meta_tiles.py
@@ -461,7 +461,7 @@ if __name__ == '__main__':
     parser.add_argument('--allowed-missing-tiles', default=2, type=int,
                         help='The maximum number of missing metatiles allowed '
                         'to continue the build process.')
-    parser.add_argument('--use-tiles-generator', default=False,
+    parser.add_argument('--use-tiles-coords-generator', default=False,
                         type=bool,
                         help='whether to use tiles coordinates generator')
 

--- a/batch-setup/make_meta_tiles.py
+++ b/batch-setup/make_meta_tiles.py
@@ -181,7 +181,7 @@ class MissingTileFinder(object):
 
             # contains zooms 0 until group zoom. the jobs between the group
             # zoom and RAWR zoom are merged into the parent at group zoom.
-            missing_low = CoordSet(max_zoom=zoom_max)
+            missing_low = CoordSet(max_zoom=zoom_max)  # 7
 
             # contains job coords at either zoom_max or split_zoom only.
             # zoom_max is a misnomer here, as it's always less than or equal to
@@ -190,10 +190,10 @@ class MissingTileFinder(object):
 
             with self.generate_missing_tiles_coords() as coords:
                 for c in coords:
-                    if c.zoom < split_zoom:
+                    if c.zoom < split_zoom:  # 10
                         # in order to not have too many jobs in the queue, we
                         # group the low zoom jobs to the zoom_max (usually 7)
-                        if c.zoom > zoom_max:
+                        if c.zoom > zoom_max:  # 7
                             c = c.zoomTo(zoom_max).container()
                         missing_low[c] = True
                     else:
@@ -201,7 +201,7 @@ class MissingTileFinder(object):
                         # (according to big_jobs[]) then enqueue the original
                         # coordinate. this is to prevent a "long tail" of huge
                         # job groups.
-                        job_coord = c.zoomTo(zoom_max).container()
+                        job_coord = c.zoomTo(zoom_max).container()  # 7
                         if not big_jobs[job_coord]:
                             c = job_coord
                         missing_high[c] = True
@@ -297,7 +297,9 @@ def _big_jobs(rawr_bucket, prefix, key_format_type, rawr_zoom, group_zoom,
     # tasks, which means we don't waste memory maintaining a huge queue of
     # pending tasks. and when something goes wrong, the stacktrace isn't buried
     # in a million others.
-    num_coords = 1 << group_zoom
+
+    # todo use the bbox to reduce the for loop
+    num_coords = 1 << group_zoom  # 7
     for x in range(num_coords):
         # kick off tasks async. each one knows its own coordinate, so we only
         # need to track the handle to know when its finished.
@@ -486,12 +488,10 @@ if __name__ == '__main__':
 
     generator = None
     if args.use_tiles_coords_generator:
-        generator = BoundingBoxTilesCoordinateGenerator(west=-4.1494623,
-                                                        south=38.350205,
-                                                        east=3.321241,
-                                                        north=47.790958,
-                                                        min_zoom=0,
-                                                        max_zoom=max(split_zoom, zoom_max))
+        generator = BoundingBoxTilesCoordinateGenerator(west=-122.188295,
+                                                        south=47.556570,
+                                                        east=-122.187670,
+                                                        north=47.556808)
 
     tile_finder = MissingTileFinder(
         buckets.missing, buckets.meta, date_prefix, missing_bucket_date_prefix,

--- a/batch-setup/make_meta_tiles.py
+++ b/batch-setup/make_meta_tiles.py
@@ -499,6 +499,7 @@ if __name__ == '__main__':
     bbox_south = -181
     bbox_east = -181
     bbox_north = -181
+    generator = None
     if args.use_tiles_coords_generator:
         if args.coords_generator_bbox_west is None or args.coords_generator_bbox_south is None or \
                 args.coords_generator_bbox_east is None or args.coords_generator_bbox_north is None:
@@ -509,10 +510,10 @@ if __name__ == '__main__':
         bbox_east = args.coords_generator_bbox_east
         bbox_north = args.coords_generator_bbox_north
 
-    generator = BoundingBoxTilesCoordinateGenerator(west=bbox_west,
-                                                    south=bbox_south,
-                                                    east=bbox_east,
-                                                    north=bbox_north)
+        generator = BoundingBoxTilesCoordinateGenerator(west=bbox_west,
+                                                        south=bbox_south,
+                                                        east=bbox_east,
+                                                        north=bbox_north)
 
     tile_finder = MissingTileFinder(
         buckets.missing, buckets.meta, date_prefix, missing_bucket_date_prefix,

--- a/batch-setup/make_meta_tiles.py
+++ b/batch-setup/make_meta_tiles.py
@@ -138,7 +138,7 @@ class MissingTileFinder(object):
 
     @contextmanager
     def generate_missing_tiles_coords(self, try_generator=False):
-        # type: () -> Iterator[Coordinate]
+        # type: () -> List[Coordinate]
         """ generate the missing tiles coordinates for low/high-zoom
             splitting
             :param try_generator: if set, it will to use the preset tiles_coords_generator if that's available
@@ -148,15 +148,18 @@ class MissingTileFinder(object):
             if try_generator and bool(self.tiles_coords_generator):
                 print("[make_meta_tiles] generate missing tiles coords "
                       "using customized generator")
-                for coord in self.tiles_coords_generator.generate_tiles_coordinates([]):
-                    yield coord
+                # todo check how yield can return
+                # for coord in self.tiles_coords_generator.generate_tiles_coordinates([]):
+                #     yield coord
+                return [coord for coord in self.tiles_coords_generator.generate_tiles_coordinates([])]
             else:
                 self.run_batch_job()
                 missing_meta_file = os.path.join(tmpdir, 'missing_meta.txt')
                 self.read_metas_to_file(missing_meta_file, compress=True)
                 with gzip.open(missing_meta_file, 'r') as fh:
-                    for line in fh:
-                        yield deserialize_coord(line)
+                    # for line in fh:
+                    #     yield deserialize_coord(line)
+                    return [deserialize_coord(line) for line in fh]
         finally:
             shutil.rmtree(tmpdir)
 

--- a/batch-setup/make_meta_tiles.py
+++ b/batch-setup/make_meta_tiles.py
@@ -180,8 +180,8 @@ class MissingTileFinder(object):
 
             print("[make_meta_tiles] Splitting into high and low zoom lists")
 
-            # contains zooms 0 until zoom_max. the jobs between the zoom_max
-            # and RAWR zoom are merged into the parent at zoom_max.
+            # contains zooms 0 until group zoom. the jobs between the group
+            # zoom and RAWR zoom are merged into the parent at group zoom.
             missing_low = CoordSet(max_zoom=zoom_max)
 
             # contains job coords at either zoom_max or split_zoom only.

--- a/batch-setup/make_rawr_tiles.py
+++ b/batch-setup/make_rawr_tiles.py
@@ -11,12 +11,14 @@ import shutil
 import tempfile
 import yaml
 import sys
+import os
 
-sys.path.insert(0, os.path.abspath('..'))
+currentdir = os.path.dirname(os.path.realpath(__file__))
+parentdir = os.path.dirname(currentdir)
+sys.path.append(parentdir)
 
 from utils.tiles import BoundingBoxTilesCoordinateGenerator
 from utils.tiles import TilesCoordinateGenerator
-
 
 
 # this struct exists to be passed into tilequeue's tilequeue_batch_enqueue

--- a/batch-setup/make_rawr_tiles.py
+++ b/batch-setup/make_rawr_tiles.py
@@ -5,14 +5,18 @@ from tilequeue.command import make_config_from_argparse
 from tilequeue.command import tilequeue_batch_enqueue
 from tilequeue.tile import deserialize_coord
 from tilequeue.tile import serialize_coord
-from utils.tiles import BoundingBoxTilesCoordinateGenerator
-from utils.tiles import TilesCoordinateGenerator
 import boto3
 import os.path
 import shutil
 import tempfile
 import yaml
 import sys
+
+sys.path.insert(0, os.path.abspath('..'))
+
+from utils.tiles import BoundingBoxTilesCoordinateGenerator
+from utils.tiles import TilesCoordinateGenerator
+
 
 
 # this struct exists to be passed into tilequeue's tilequeue_batch_enqueue
@@ -206,8 +210,6 @@ def make_rawr_tiles(rawr_config_file, missing_config_file, missing_bucket,
 
 
 if __name__ == '__main__':
-    sys.path.insert(0, os.path.abspath('..'))
-
     import argparse
 
     parser = argparse.ArgumentParser("Render missing RAWR tiles")

--- a/batch-setup/make_rawr_tiles.py
+++ b/batch-setup/make_rawr_tiles.py
@@ -250,10 +250,10 @@ if __name__ == '__main__':
 
     generator = None
     if args.use_tiles_coords_generator:
-        generator = BoundingBoxTilesCoordinateGenerator(west=-122.185508,
-                                                        south=47.587435,
-                                                        east=-122.168342,
-                                                        north=47.602600)
+        generator = BoundingBoxTilesCoordinateGenerator(west=-122.188295,
+                                                        south=47.556570,
+                                                        east=-122.187670,
+                                                        north=47.556808)
 
     make_rawr_tiles(args.config, args.missing_config, args.missing_bucket,
                     args.bucket, region, args.date_prefix, args.retries,

--- a/batch-setup/make_rawr_tiles.py
+++ b/batch-setup/make_rawr_tiles.py
@@ -18,8 +18,8 @@ currentdir = os.path.dirname(os.path.realpath(__file__))
 parentdir = os.path.dirname(currentdir)
 sys.path.append(parentdir)
 
-from utils.tiles import BoundingBoxTilesCoordinateGenerator
-from utils.tiles import TilesCoordinateGenerator
+from utils.tiles import BoundingBoxTileCoordinatesGenerator
+from utils.tiles import TileCoordinatesGenerator
 
 
 # this struct exists to be passed into tilequeue's tilequeue_batch_enqueue
@@ -167,7 +167,7 @@ def make_rawr_tiles(rawr_config_file, missing_config_file, missing_bucket,
                     rawr_bucket, region, date_prefix, retry_attempts,
                     tile_zoom=10, key_format_type='prefix-hash',
                     tile_coords_generator=None):
-    # type: (str, str, str, str, str, str, int, int, str, TilesCoordinateGenerator) -> None
+    # type: (str, str, str, str, str, str, int, int, str, TileCoordinatesGenerator) -> None
     """
     Finds out which jobs need to be run to have a complete RAWR tiles bucket,
     runs them and waits for them to complete. If the bucket still isn't
@@ -263,7 +263,7 @@ if __name__ == '__main__':
         min_x, min_y, max_x, max_y = list(map(float, bboxes))
         assert min_x < max_x, 'Invalid bbox. X: {} not less than {}'.format(min_x, max_x)
         assert min_y < max_y, 'Invalid bbox. Y: {} not less than {}'.format(min_y, max_y)
-        generator = BoundingBoxTilesCoordinateGenerator(min_x=min_x,
+        generator = BoundingBoxTileCoordinatesGenerator(min_x=min_x,
                                                         min_y=min_y,
                                                         max_x=max_x,
                                                         max_y=max_y)

--- a/batch-setup/make_rawr_tiles.py
+++ b/batch-setup/make_rawr_tiles.py
@@ -12,6 +12,7 @@ import os.path
 import shutil
 import tempfile
 import yaml
+import sys
 
 
 # this struct exists to be passed into tilequeue's tilequeue_batch_enqueue
@@ -205,6 +206,8 @@ def make_rawr_tiles(rawr_config_file, missing_config_file, missing_bucket,
 
 
 if __name__ == '__main__':
+    sys.path.insert(0, os.path.abspath('..'))
+
     import argparse
 
     parser = argparse.ArgumentParser("Render missing RAWR tiles")

--- a/batch-setup/make_rawr_tiles.py
+++ b/batch-setup/make_rawr_tiles.py
@@ -241,8 +241,8 @@ if __name__ == '__main__':
                         "enumeration logs in while calculating missing tiles.")
     parser.add_argument('--use-tile-coords-generator', type=lambda x: bool(strtobool(x)), nargs='?',
                         const=True, default=False)
-    parser.add_argument('--tile-coords-generator-bbox', help="Comma separated coordinates of a bounding box "
-                                                             "min_x, min_y, max_x, max_y")
+    parser.add_argument('--tile-coords-generator-bbox', type=str, help="Comma separated coordinates of a bounding box "
+                                                                       "min_x, min_y, max_x, max_y")
 
     args = parser.parse_args()
     assert args.key_format_type in ('prefix-hash', 'hash-prefix')

--- a/batch-setup/make_rawr_tiles.py
+++ b/batch-setup/make_rawr_tiles.py
@@ -39,11 +39,15 @@ def all_tiles_at(zoom):
             yield Coordinate(zoom=zoom, column=x, row=y)
 
 
+generate_used = False
+
+
 def missing_tiles(missing_bucket, rawr_bucket, date_prefix, region,
                   key_format_type, config, zoom, tiles_coords_generator=None):
     from make_meta_tiles import MissingTileFinder
-
-    if bool(tiles_coords_generator):
+    global generate_used
+    if not generate_used and bool(tiles_coords_generator):
+        generate_used = True
         return set([c for c in tiles_coords_generator.
                    generate_tiles_coordinates([zoom])])
     else:

--- a/batch-setup/make_rawr_tiles.py
+++ b/batch-setup/make_rawr_tiles.py
@@ -247,10 +247,10 @@ if __name__ == '__main__':
 
     generator = None
     if args.use_tiles_coords_generator:
-        generator = BoundingBoxTilesCoordinateGenerator(west=-4.1494623,
-                                                        south=38.350205,
-                                                        east=3.321241,
-                                                        north=47.790958)
+        generator = BoundingBoxTilesCoordinateGenerator(west=-122.185508,
+                                                        south=47.587435,
+                                                        east=-122.168342,
+                                                        north=47.602600)
 
     make_rawr_tiles(args.config, args.missing_config, args.missing_bucket,
                     args.bucket, region, args.date_prefix, args.retries,

--- a/batch-setup/make_rawr_tiles.py
+++ b/batch-setup/make_rawr_tiles.py
@@ -238,7 +238,7 @@ if __name__ == '__main__':
                         "written out by make_tiles.py")
     parser.add_argument('missing_bucket', help="Bucket to store tile "
                         "enumeration logs in while calculating missing tiles.")
-    parser.add_argument('--use-tiles-generator',
+    parser.add_argument('--use-tiles-coords-generator',
                         default=False,
                         type=bool,
                         help="whether to use tiles coordinates generator")

--- a/batch-setup/make_rawr_tiles.py
+++ b/batch-setup/make_rawr_tiles.py
@@ -69,6 +69,9 @@ def missing_jobs(missing_bucket, rawr_bucket, date_prefix, region, config,
     tiles = missing_tiles(
         missing_bucket, rawr_bucket, date_prefix, region, key_format_type,
         config, tile_zoom, tiles_coords_generator)
+
+    # the rawr tiles of `tile_zoom` is actually built by AWS batch jobs of
+    # `job_zoom` so we need to do a zoomTo here to find the corresponding jobs
     jobs = set(coord.zoomTo(job_zoom).container() for coord in tiles)
 
     print("[make_rawr_tiles] Missing %d tiles (%d jobs)" % (len(tiles), len(jobs)))

--- a/batch-setup/make_rawr_tiles.py
+++ b/batch-setup/make_rawr_tiles.py
@@ -262,6 +262,7 @@ if __name__ == '__main__':
     bbox_south = -181
     bbox_east = -181
     bbox_north = -181
+    generator = None
     if args.use_tiles_coords_generator:
         if args.coords_generator_bbox_west is None or args.coords_generator_bbox_south is None or \
                 args.coords_generator_bbox_east is None or args.coords_generator_bbox_north is None:
@@ -272,10 +273,10 @@ if __name__ == '__main__':
         bbox_east = args.coords_generator_bbox_east
         bbox_north = args.coords_generator_bbox_north
 
-    generator = BoundingBoxTilesCoordinateGenerator(west=bbox_west,
-                                                    south=bbox_south,
-                                                    east=bbox_east,
-                                                    north=bbox_north)
+        generator = BoundingBoxTilesCoordinateGenerator(west=bbox_west,
+                                                        south=bbox_south,
+                                                        east=bbox_east,
+                                                        north=bbox_north)
 
     make_rawr_tiles(args.config, args.missing_config, args.missing_bucket,
                     args.bucket, region, args.date_prefix, args.retries,

--- a/batch-setup/provision.sh
+++ b/batch-setup/provision.sh
@@ -153,9 +153,9 @@ set -x
 
 python -u /usr/local/src/tileops/batch-setup/make_tiles.py --num-db-replicas $NUM_DB_REPLICAS --max-vcpus $MAX_VCPUS $RUN_ID --missing-bucket $MISSING_BUCKET --meta-date-prefix $META_DATE_PREFIX $RAWR_BUCKET $META_BUCKET $DB_PASSWORD --overrides $JOB_ENV_OVERRIDES
 
-python -u /usr/local/src/tileops/batch-setup/make_rawr_tiles.py --config enqueue-rawr-batch.config.yaml --key-format-type hash-prefix --use-tile-coords-generator --tile-coords-generator-bbox "$BBOX" $RAWR_BUCKET $RUN_ID $MISSING_BUCKET
+python -u /usr/local/src/tileops/batch-setup/make_rawr_tiles.py --config enqueue-rawr-batch.config.yaml --key-format-type hash-prefix --use-tile-coords-generator --tile-coords-generator-bbox \"$BBOX\" $RAWR_BUCKET $RUN_ID $MISSING_BUCKET
 
-python -u /usr/local/src/tileops/batch-setup/make_meta_tiles.py --date-prefix $META_DATE_PREFIX --missing-bucket $MISSING_BUCKET --key-format-type hash-prefix --metatile-size $METATILE_SIZE --use-tile-coords-generator --tile-coords-generator-bbox "$BBOX" $RAWR_BUCKET $META_BUCKET $RUN_ID
+python -u /usr/local/src/tileops/batch-setup/make_meta_tiles.py --date-prefix $META_DATE_PREFIX --missing-bucket $MISSING_BUCKET --key-format-type hash-prefix --metatile-size $METATILE_SIZE --use-tile-coords-generator --tile-coords-generator-bbox \"$BBOX\" $RAWR_BUCKET $META_BUCKET $RUN_ID
 EOF
 chmod +x /usr/local/bin/bbox_rebuild.sh
 

--- a/batch-setup/provision.sh
+++ b/batch-setup/provision.sh
@@ -152,7 +152,9 @@ set -e
 set -x
 
 python -u /usr/local/src/tileops/batch-setup/make_tiles.py --num-db-replicas $NUM_DB_REPLICAS --max-vcpus $MAX_VCPUS $RUN_ID --missing-bucket $MISSING_BUCKET --meta-date-prefix $META_DATE_PREFIX $RAWR_BUCKET $META_BUCKET $DB_PASSWORD --overrides $JOB_ENV_OVERRIDES
+
 python -u /usr/local/src/tileops/batch-setup/make_rawr_tiles.py --config enqueue-rawr-batch.config.yaml --key-format-type hash-prefix --use-tiles-coords-generator --coords-generator-bbox-west $BBOX_WEST --coords-generator-bbox-south $BBOX_SOUTH --coords-generator-bbox-east $BBOX_EAST --coords-generator-bbox-north $BBOX_NORTH $RAWR_BUCKET $RUN_ID $MISSING_BUCKET
+
 python -u /usr/local/src/tileops/batch-setup/make_meta_tiles.py --date-prefix $META_DATE_PREFIX --missing-bucket $MISSING_BUCKET --key-format-type hash-prefix --metatile-size $METATILE_SIZE --use-tiles-coords-generator --coords-generator-bbox-west $BBOX_WEST --coords-generator-bbox-south $BBOX_SOUTH --coords-generator-bbox-east $BBOX_EAST --coords-generator-bbox-north $BBOX_NORTH $RAWR_BUCKET $META_BUCKET $RUN_ID
 EOF
 chmod +x /usr/local/bin/bbox_rebuild.sh

--- a/batch-setup/provision.sh
+++ b/batch-setup/provision.sh
@@ -127,12 +127,12 @@ set -x
 
 python -u /usr/local/src/tileops/import/import.py --find-ip-address meta --planet-url \$PLANET_URL --planet-md5-url \$PLANET_MD5_URL --run-id \$RUN_ID --vector-datasource-version \$VECTOR_DATASOURCE_VERSION \$TILE_ASSET_BUCKET \$AWS_DEFAULT_REGION \
        \$TILE_ASSET_PROFILE_ARN \$DB_PASSWORD
-python -u /usr/local/src/tileops/batch-setup/make_tiles.py --num-db-replicas \$NUM_DB_REPLICAS \
-       --max-vcpus \$MAX_VCPUS \$RUN_ID --missing-bucket \$MISSING_BUCKET \
-       --meta-date-prefix \$META_DATE_PREFIX \$RAWR_BUCKET \$META_BUCKET \
-       \$DB_PASSWORD --overrides \$JOB_ENV_OVERRIDES
-python -u /usr/local/src/tileops/batch-setup/make_rawr_tiles.py --config enqueue-rawr-batch.config.yaml --key-format-type hash-prefix \
-       \$RAWR_BUCKET \$RUN_ID \$MISSING_BUCKET
+python -u /usr/local/src/tileops/batch-setup/make_tiles.py --num-db-replicas $NUM_DB_REPLICAS --max-vcpus $MAX_VCPUS $RUN_ID --missing-bucket $MISSING_BUCKET --meta-date-prefix $META_DATE_PREFIX $RAWR_BUCKET $META_BUCKET $DB_PASSWORD --overrides $JOB_ENV_OVERRIDES
+python -u /usr/local/src/tileops/batch-setup/make_tiles.py --num-db-replicas 1 --max-vcpus $MAX_VCPUS $RUN_ID --missing-bucket $MISSING_BUCKET --meta-date-prefix $META_DATE_PREFIX $RAWR_BUCKET $META_BUCKET $DB_PASSWORD --overrides $JOB_ENV_OVERRIDES
+
+
+
+python -u /usr/local/src/tileops/batch-setup/make_rawr_tiles.py --config enqueue-rawr-batch.config.yaml --key-format-type hash-prefix --use-tiles-coords-generator true $RAWR_BUCKET $RUN_ID $MISSING_BUCKET
 python -u /usr/local/src/tileops/batch-setup/make_meta_tiles.py --date-prefix \$META_DATE_PREFIX --missing-bucket \$MISSING_BUCKET \
        --key-format-type hash-prefix --metatile-size \$METATILE_SIZE \$RAWR_BUCKET \$META_BUCKET \$RUN_ID
 EOF

--- a/batch-setup/provision.sh
+++ b/batch-setup/provision.sh
@@ -153,7 +153,7 @@ set -x
 
 python -u /usr/local/src/tileops/batch-setup/make_tiles.py --num-db-replicas $NUM_DB_REPLICAS --max-vcpus $MAX_VCPUS $RUN_ID --missing-bucket $MISSING_BUCKET --meta-date-prefix $META_DATE_PREFIX $RAWR_BUCKET $META_BUCKET $DB_PASSWORD --overrides $JOB_ENV_OVERRIDES
 
-python -u /usr/local/src/tileops/batch-setup/make_rawr_tiles.py --config enqueue-rawr-batch.config.yaml --key-format-type hash-prefix --use-tile-coords-generator --tile-coords-bbox $BBOX $RAWR_BUCKET $RUN_ID $MISSING_BUCKET
+python -u /usr/local/src/tileops/batch-setup/make_rawr_tiles.py --config enqueue-rawr-batch.config.yaml --key-format-type hash-prefix --use-tile-coords-generator --tile-coords-generator-bbox $BBOX $RAWR_BUCKET $RUN_ID $MISSING_BUCKET
 
 python -u /usr/local/src/tileops/batch-setup/make_meta_tiles.py --date-prefix $META_DATE_PREFIX --missing-bucket $MISSING_BUCKET --key-format-type hash-prefix --metatile-size $METATILE_SIZE --use-tile-coords-generator --tile-coords-generator-bbox $BBOX $RAWR_BUCKET $META_BUCKET $RUN_ID
 EOF

--- a/batch-setup/provision.sh
+++ b/batch-setup/provision.sh
@@ -133,8 +133,7 @@ python -u /usr/local/src/tileops/batch-setup/make_tiles.py --num-db-replicas 1 -
 
 
 python -u /usr/local/src/tileops/batch-setup/make_rawr_tiles.py --config enqueue-rawr-batch.config.yaml --key-format-type hash-prefix --use-tiles-coords-generator true $RAWR_BUCKET $RUN_ID $MISSING_BUCKET
-python -u /usr/local/src/tileops/batch-setup/make_meta_tiles.py --date-prefix \$META_DATE_PREFIX --missing-bucket \$MISSING_BUCKET \
-       --key-format-type hash-prefix --metatile-size \$METATILE_SIZE \$RAWR_BUCKET \$META_BUCKET \$RUN_ID
+python -u /usr/local/src/tileops/batch-setup/make_meta_tiles.py --date-prefix $META_DATE_PREFIX --missing-bucket $MISSING_BUCKET --key-format-type hash-prefix --metatile-size $METATILE_SIZE --use-tiles-coords-generator true $RAWR_BUCKET $META_BUCKET $RUN_ID
 EOF
 chmod +x /usr/local/bin/run.sh
 

--- a/batch-setup/provision.sh
+++ b/batch-setup/provision.sh
@@ -153,9 +153,9 @@ set -x
 
 python -u /usr/local/src/tileops/batch-setup/make_tiles.py --num-db-replicas $NUM_DB_REPLICAS --max-vcpus $MAX_VCPUS $RUN_ID --missing-bucket $MISSING_BUCKET --meta-date-prefix $META_DATE_PREFIX $RAWR_BUCKET $META_BUCKET $DB_PASSWORD --overrides $JOB_ENV_OVERRIDES
 
-python -u /usr/local/src/tileops/batch-setup/make_rawr_tiles.py --config enqueue-rawr-batch.config.yaml --key-format-type hash-prefix --use-tiles-coords-generator --coords-generator-bbox-west $BBOX_WEST --coords-generator-bbox-south $BBOX_SOUTH --coords-generator-bbox-east $BBOX_EAST --coords-generator-bbox-north $BBOX_NORTH $RAWR_BUCKET $RUN_ID $MISSING_BUCKET
+python -u /usr/local/src/tileops/batch-setup/make_rawr_tiles.py --config enqueue-rawr-batch.config.yaml --key-format-type hash-prefix --use-tile-coords-generator --tile-coords-bbox $BBOX $RAWR_BUCKET $RUN_ID $MISSING_BUCKET
 
-python -u /usr/local/src/tileops/batch-setup/make_meta_tiles.py --date-prefix $META_DATE_PREFIX --missing-bucket $MISSING_BUCKET --key-format-type hash-prefix --metatile-size $METATILE_SIZE --use-tiles-coords-generator --coords-generator-bbox-west $BBOX_WEST --coords-generator-bbox-south $BBOX_SOUTH --coords-generator-bbox-east $BBOX_EAST --coords-generator-bbox-north $BBOX_NORTH $RAWR_BUCKET $META_BUCKET $RUN_ID
+python -u /usr/local/src/tileops/batch-setup/make_meta_tiles.py --date-prefix $META_DATE_PREFIX --missing-bucket $MISSING_BUCKET --key-format-type hash-prefix --metatile-size $METATILE_SIZE --use-tile-coords-generator --tile-coords-generator-bbox $BBOX $RAWR_BUCKET $META_BUCKET $RUN_ID
 EOF
 chmod +x /usr/local/bin/bbox_rebuild.sh
 

--- a/batch-setup/provision.sh
+++ b/batch-setup/provision.sh
@@ -153,9 +153,9 @@ set -x
 
 python -u /usr/local/src/tileops/batch-setup/make_tiles.py --num-db-replicas $NUM_DB_REPLICAS --max-vcpus $MAX_VCPUS $RUN_ID --missing-bucket $MISSING_BUCKET --meta-date-prefix $META_DATE_PREFIX $RAWR_BUCKET $META_BUCKET $DB_PASSWORD --overrides $JOB_ENV_OVERRIDES
 
-python -u /usr/local/src/tileops/batch-setup/make_rawr_tiles.py --config enqueue-rawr-batch.config.yaml --key-format-type hash-prefix --use-tile-coords-generator --tile-coords-generator-bbox \"$BBOX\" $RAWR_BUCKET $RUN_ID $MISSING_BUCKET
+python -u /usr/local/src/tileops/batch-setup/make_rawr_tiles.py --config enqueue-rawr-batch.config.yaml --key-format-type hash-prefix --use-tile-coords-generator --tile-coords-generator-bbox=$BBOX $RAWR_BUCKET $RUN_ID $MISSING_BUCKET
 
-python -u /usr/local/src/tileops/batch-setup/make_meta_tiles.py --date-prefix $META_DATE_PREFIX --missing-bucket $MISSING_BUCKET --key-format-type hash-prefix --metatile-size $METATILE_SIZE --use-tile-coords-generator --tile-coords-generator-bbox \"$BBOX\" $RAWR_BUCKET $META_BUCKET $RUN_ID
+python -u /usr/local/src/tileops/batch-setup/make_meta_tiles.py --date-prefix $META_DATE_PREFIX --missing-bucket $MISSING_BUCKET --key-format-type hash-prefix --metatile-size $METATILE_SIZE --use-tile-coords-generator --tile-coords-generator-bbox=$BBOX $RAWR_BUCKET $META_BUCKET $RUN_ID
 EOF
 chmod +x /usr/local/bin/bbox_rebuild.sh
 

--- a/batch-setup/provision.sh
+++ b/batch-setup/provision.sh
@@ -153,9 +153,9 @@ set -x
 
 python -u /usr/local/src/tileops/batch-setup/make_tiles.py --num-db-replicas $NUM_DB_REPLICAS --max-vcpus $MAX_VCPUS $RUN_ID --missing-bucket $MISSING_BUCKET --meta-date-prefix $META_DATE_PREFIX $RAWR_BUCKET $META_BUCKET $DB_PASSWORD --overrides $JOB_ENV_OVERRIDES
 
-python -u /usr/local/src/tileops/batch-setup/make_rawr_tiles.py --config enqueue-rawr-batch.config.yaml --key-format-type hash-prefix --use-tile-coords-generator --tile-coords-generator-bbox $BBOX $RAWR_BUCKET $RUN_ID $MISSING_BUCKET
+python -u /usr/local/src/tileops/batch-setup/make_rawr_tiles.py --config enqueue-rawr-batch.config.yaml --key-format-type hash-prefix --use-tile-coords-generator --tile-coords-generator-bbox "$BBOX" $RAWR_BUCKET $RUN_ID $MISSING_BUCKET
 
-python -u /usr/local/src/tileops/batch-setup/make_meta_tiles.py --date-prefix $META_DATE_PREFIX --missing-bucket $MISSING_BUCKET --key-format-type hash-prefix --metatile-size $METATILE_SIZE --use-tile-coords-generator --tile-coords-generator-bbox $BBOX $RAWR_BUCKET $META_BUCKET $RUN_ID
+python -u /usr/local/src/tileops/batch-setup/make_meta_tiles.py --date-prefix $META_DATE_PREFIX --missing-bucket $MISSING_BUCKET --key-format-type hash-prefix --metatile-size $METATILE_SIZE --use-tile-coords-generator --tile-coords-generator-bbox "$BBOX" $RAWR_BUCKET $META_BUCKET $RUN_ID
 EOF
 chmod +x /usr/local/bin/bbox_rebuild.sh
 

--- a/doc/batch/README.md
+++ b/doc/batch/README.md
@@ -126,4 +126,4 @@ After each build is finished, to rebuild the tiles that intersects with a boundi
 BBOX=-123.571730,45.263862,-118.386183,48.760348 /usr/bin/nohup /usr/local/bin/bbox_rebuild.sh &
 ```
 
-(the above command will rebuild all the rawr and meta tiles that wraps the bounding box BBOX_WEST=-123.571730 BBOX_SOUTH=45.263862 BBOX_EAST=-118.386183 BBOX_NORTH=48.760348)
+(the above command will rebuild all the rawr and meta tiles that wraps the bounding box min_x=-123.571730 min_y=45.263862 max_x=-118.386183 max_y=48.760348)

--- a/doc/batch/README.md
+++ b/doc/batch/README.md
@@ -123,7 +123,7 @@ Furthermore, it also takes `--tile` and `--file` arguments. `--tile` will only e
 After each build is finished, to rebuild the tiles that intersects with a bounding box, you can logon to the tiles ops runner EC2 instance, and trigger a command similar to the following
 
 ```
-BBOX_WEST=-123.571730 BBOX_SOUTH=45.263862 BBOX_EAST=-118.386183 BBOX_NORTH=48.760348 /usr/bin/nohup /usr/local/bin/bbox_rebuild.sh &
+BBOX=-123.571730,45.263862,-118.386183,48.760348 /usr/bin/nohup /usr/local/bin/bbox_rebuild.sh &
 ```
 
 (the above command will rebuild all the rawr and meta tiles that wraps the bounding box BBOX_WEST=-123.571730 BBOX_SOUTH=45.263862 BBOX_EAST=-118.386183 BBOX_NORTH=48.760348)

--- a/doc/batch/README.md
+++ b/doc/batch/README.md
@@ -117,3 +117,13 @@ When running the enqueue, update the configuration file to contain the appropria
 *NOTE*: Jobs will be enqueued at the batch `queue-zoom` configuration value. This is expected to be 7.
 The `pyramid` option to `batch-enqueue` will additionally enqueue all tiles lower than the `queue-zoom`, which is required for low zoom tiles. Assuming a `queue-zoom` of 7, the jobs enqueued will be zooms `[0, 7]` with `--pyramid`.
 Furthermore, it also takes `--tile` and `--file` arguments. `--tile` will only enqueue a single tile, and `--file` will enqueue all tiles in a particular file. These are useful for initially testing a single tile to ensure that batch is set up correctly, and for iterating on enqueueing additional tiles to reprocess.
+
+
+# Rebuild
+After each build is finished, to rebuild the tiles that intersects with a bounding box, you can logon to the tiles ops runner EC2 instance, and trigger a command similar to the following
+
+```
+BBOX_WEST=-123.571730 BBOX_SOUTH=45.263862 BBOX_EAST=-118.386183 BBOX_NORTH=48.760348 /usr/bin/nohup /usr/local/bin/bbox_rebuild.sh &
+```
+
+(the above command will rebuild all the rawr and meta tiles that wraps the bounding box BBOX_WEST=-123.571730 BBOX_SOUTH=45.263862 BBOX_EAST=-118.386183 BBOX_NORTH=48.760348)

--- a/doc/python_setup.md
+++ b/doc/python_setup.md
@@ -12,7 +12,7 @@ The instructions below will assume Amazon Linux, but similar packages should exi
 
 1. While in the `tileops` directory, create a Pipenv environment:
 
-       pipenv install
+       pipenv install -d
 
 1. Use Pipenv to enter a shell in the virtual environment:
 

--- a/utils/constants.py
+++ b/utils/constants.py
@@ -1,0 +1,2 @@
+MAX_TILE_ZOOM = 15  # 15 tilezen's max supported zoom
+MIN_TILE_ZOOM = 0

--- a/utils/test_tiles.py
+++ b/utils/test_tiles.py
@@ -34,12 +34,14 @@ def test_tiles_within_bbox():
     zoomedCoord = coords[0].zoomTo(7).container()
     assert Coordinate(44, 20, 7) == zoomedCoord
 
-    generator4 = BoundingBoxTilesCoordinateGenerator(-122.924358,
-                                                     47.131730,
-                                                     -121.861431,
-                                                     47.960414)
+    generator4 = BoundingBoxTilesCoordinateGenerator(-123.571730,
+                                                     45.263862,
+                                                     -118.386183,
+                                                     48.760348)
 
-    res = generator4.generate_tiles_coordinates([9])
-    coords = [c for c in res]
-    zoomedCoord = coords[0].zoomTo(7).container()
-    assert Coordinate(44, 20, 7) == zoomedCoord
+    res = generator4.generate_tiles_coordinates([10])
+    zoomedCoords = set(coord.zoomTo(7).container() for coord in res)
+
+    assert set([Coordinate(44, 20, 7), Coordinate(44, 21, 7), Coordinate(45, 20, 7), Coordinate(45, 21, 7)]) == \
+           zoomedCoords
+

--- a/utils/test_tiles.py
+++ b/utils/test_tiles.py
@@ -22,10 +22,14 @@ def test_tiles_within_bbox():
     expected = [Coordinate(357, 164, 10)]
     assert expected == [c for c in res]
 
-    generator2 = BoundingBoxTilesCoordinateGenerator(-122.188295,
+    generator3 = BoundingBoxTilesCoordinateGenerator(-122.188295,
                                                      47.556570,
                                                      -122.187670,
                                                      47.556808)
-    res = generator2.generate_tiles_coordinates([15])
+    res = generator3.generate_tiles_coordinates([15])
     expected = [Coordinate(11450, 5262, 15)]
-    assert expected == [c for c in res]
+    coords = [c for c in res]
+    assert expected == coords
+
+    zoomedCoord = coords[0].zoomTo(7).container()
+    assert Coordinate(44, 20, 7) == zoomedCoord  # on AWS batch the job name is 7-20-44

--- a/utils/test_tiles.py
+++ b/utils/test_tiles.py
@@ -32,4 +32,14 @@ def test_tiles_within_bbox():
     assert expected == coords
 
     zoomedCoord = coords[0].zoomTo(7).container()
-    assert Coordinate(44, 20, 7) == zoomedCoord  # on AWS batch the job name is 7-20-44
+    assert Coordinate(44, 20, 7) == zoomedCoord
+
+    generator4 = BoundingBoxTilesCoordinateGenerator(-122.924358,
+                                                     47.131730,
+                                                     -121.861431,
+                                                     47.960414)
+
+    res = generator4.generate_tiles_coordinates([9])
+    coords = [c for c in res]
+    zoomedCoord = coords[0].zoomTo(7).container()
+    assert Coordinate(44, 20, 7) == zoomedCoord

--- a/utils/test_tiles.py
+++ b/utils/test_tiles.py
@@ -21,3 +21,11 @@ def test_tiles_within_bbox():
     res = generator2.generate_tiles_coordinates([10])
     expected = [Coordinate(357, 164, 10)]
     assert expected == [c for c in res]
+
+    generator2 = BoundingBoxTilesCoordinateGenerator(-122.188295,
+                                                     47.556570,
+                                                     -122.187670,
+                                                     47.556808)
+    res = generator2.generate_tiles_coordinates([15])
+    expected = [Coordinate(11450, 5262, 15)]
+    assert expected == [c for c in res]

--- a/utils/test_tiles.py
+++ b/utils/test_tiles.py
@@ -1,12 +1,12 @@
-from utils.tiles import BoundingBoxTilesCoordinateGenerator
+from utils.tiles import BoundingBoxTileCoordinatesGenerator
 from ModestMaps.Core import Coordinate
 
 
 def test_tiles_within_bbox():
-    generator1 = BoundingBoxTilesCoordinateGenerator(-4.1494623,
-                                                    38.350205,
-                                                    3.321241,
-                                                    47.790958)
+    generator1 = BoundingBoxTileCoordinatesGenerator(-4.1494623,
+                                                     38.350205,
+                                                     3.321241,
+                                                     47.790958)
     res = generator1.generate_tiles_coordinates([5])
     expected = [Coordinate(11, 15, 5),
                 Coordinate(12, 15, 5),
@@ -14,7 +14,7 @@ def test_tiles_within_bbox():
                 Coordinate(12, 16, 5)]
     assert expected == [c for c in res]
 
-    generator2 = BoundingBoxTilesCoordinateGenerator(-122.185508,
+    generator2 = BoundingBoxTileCoordinatesGenerator(-122.185508,
                                                      47.587435,
                                                      -122.168342,
                                                      47.602600)
@@ -22,7 +22,7 @@ def test_tiles_within_bbox():
     expected = [Coordinate(357, 164, 10)]
     assert expected == [c for c in res]
 
-    generator3 = BoundingBoxTilesCoordinateGenerator(-122.188295,
+    generator3 = BoundingBoxTileCoordinatesGenerator(-122.188295,
                                                      47.556570,
                                                      -122.187670,
                                                      47.556808)
@@ -34,7 +34,7 @@ def test_tiles_within_bbox():
     zoomedCoord = coords[0].zoomTo(7).container()
     assert Coordinate(44, 20, 7) == zoomedCoord
 
-    generator4 = BoundingBoxTilesCoordinateGenerator(-123.571730,
+    generator4 = BoundingBoxTileCoordinatesGenerator(-123.571730,
                                                      45.263862,
                                                      -118.386183,
                                                      48.760348)

--- a/utils/test_tiles.py
+++ b/utils/test_tiles.py
@@ -3,13 +3,21 @@ from ModestMaps.Core import Coordinate
 
 
 def test_tiles_within_bbox():
-    generator = BoundingBoxTilesCoordinateGenerator(-4.1494623,
+    generator1 = BoundingBoxTilesCoordinateGenerator(-4.1494623,
                                                     38.350205,
                                                     3.321241,
                                                     47.790958)
-    res = generator.generate_tiles_coordinates([5])
+    res = generator1.generate_tiles_coordinates([5])
     expected = [Coordinate(11, 15, 5),
                 Coordinate(12, 15, 5),
                 Coordinate(11, 16, 5),
                 Coordinate(12, 16, 5)]
+    assert expected == [c for c in res]
+
+    generator2 = BoundingBoxTilesCoordinateGenerator(-122.185508,
+                                                     47.587435,
+                                                     -122.168342,
+                                                     47.602600)
+    res = generator2.generate_tiles_coordinates([10])
+    expected = [Coordinate(357, 164, 10)]
     assert expected == [c for c in res]

--- a/utils/test_tiles.py
+++ b/utils/test_tiles.py
@@ -1,0 +1,15 @@
+from utils.tiles import BoundingBoxTilesCoordinateGenerator
+from ModestMaps.Core import Coordinate
+
+
+def test_tiles_within_bbox():
+    generator = BoundingBoxTilesCoordinateGenerator(-4.1494623,
+                                                    38.350205,
+                                                    3.321241,
+                                                    47.790958)
+    res = generator.generate_tiles_coordinates([5])
+    expected = [Coordinate(11, 15, 5),
+                Coordinate(12, 15, 5),
+                Coordinate(11, 16, 5),
+                Coordinate(12, 16, 5)]
+    assert expected == [c for c in res]

--- a/utils/tiles.py
+++ b/utils/tiles.py
@@ -57,7 +57,7 @@ class BoundingBoxTilesCoordinateGenerator(TilesCoordinateGenerator):
         :param min_zoom: the minimum zoom(inclusive) it can generate tiles for
         :param max_zoom: the maximum zoom(inclusive) it can generate tiles for
         """
-        super().__init__(min_zoom=min_zoom, max_zoom=max_zoom)
+        super(BoundingBoxTilesCoordinateGenerator, self).__init__(min_zoom=min_zoom, max_zoom=max_zoom)
         self.west = west
         self.south = south
         self.east = east

--- a/utils/tiles.py
+++ b/utils/tiles.py
@@ -1,8 +1,6 @@
 from ModestMaps.Core import Coordinate
 from mercantile import tiles
 from mercantile import tile
-#from typing import Iterator
-#from typing import List
 from utils.constants import MAX_TILE_ZOOM
 from utils.constants import MIN_TILE_ZOOM
 
@@ -47,22 +45,22 @@ class BoundingBoxTilesCoordinateGenerator(TilesCoordinateGenerator):
     """ Generate the tiles overlapped by a geographic bounding box within a
     range """
 
-    def __init__(self, west, south, east, north, min_zoom=MIN_TILE_ZOOM,
+    def __init__(self, min_x, min_y, max_x, max_y, min_zoom=MIN_TILE_ZOOM,
                  max_zoom=MAX_TILE_ZOOM):
         # type: (float, float, float, float, int, int) -> None
         """
-        :param west: longitude of the west boundary
-        :param south: latitude of the south boundary
-        :param east: longitude of the east boundary
-        :param north: latitude of the north boundary
+        :param min_x: longitude of the west boundary
+        :param min_y: latitude of the south boundary
+        :param max_x: longitude of the east boundary
+        :param max_y: latitude of the north boundary
         :param min_zoom: the minimum zoom(inclusive) it can generate tiles for
         :param max_zoom: the maximum zoom(inclusive) it can generate tiles for
         """
         super(BoundingBoxTilesCoordinateGenerator, self).__init__(min_zoom=min_zoom, max_zoom=max_zoom)
-        self.west = west
-        self.south = south
-        self.east = east
-        self.north = north
+        self.min_x = min_x
+        self.min_y = min_y
+        self.max_x = max_x
+        self.max_y = max_y
 
     @staticmethod
     def convert_mercantile(m_tile):
@@ -72,7 +70,7 @@ class BoundingBoxTilesCoordinateGenerator(TilesCoordinateGenerator):
     def generate_tiles_coordinates(self, zooms):
         # type: (List[int]) -> Iterator[Coordinate]
         """ Get the tiles overlapped by a geographic bounding box """
-        for m_tile in tiles(self.west, self.south, self.east, self.north,
+        for m_tile in tiles(self.min_x, self.min_y, self.max_x, self.max_y,
                             self.filter_zooms_in_range(zooms), True):
             yield BoundingBoxTilesCoordinateGenerator.\
                 convert_mercantile(m_tile)

--- a/utils/tiles.py
+++ b/utils/tiles.py
@@ -17,6 +17,7 @@ class TilesCoordinateGenerator(object):
         :param min_zoom: the minimum zoom(inclusive) it can generate tiles for
         :param max_zoom: the maximum zoom(inclusive) it can generate tiles for
         """
+        assert min_zoom <= max_zoom
         self.min_zoom = min_zoom
         self.max_zoom = max_zoom
 

--- a/utils/tiles.py
+++ b/utils/tiles.py
@@ -5,7 +5,7 @@ from utils.constants import MAX_TILE_ZOOM
 from utils.constants import MIN_TILE_ZOOM
 
 
-class TilesCoordinateGenerator(object):
+class TileCoordinatesGenerator(object):
     """
     Generate tiles EPSG:3857 coordinates from a list of zooms within a range
     """
@@ -41,7 +41,7 @@ class TilesCoordinateGenerator(object):
                     yield Coordinate(zoom=zoom, column=x, row=y)
 
 
-class BoundingBoxTilesCoordinateGenerator(TilesCoordinateGenerator):
+class BoundingBoxTileCoordinatesGenerator(TileCoordinatesGenerator):
     """ Generate the tiles overlapped by a geographic bounding box within a
     range """
 
@@ -56,7 +56,7 @@ class BoundingBoxTilesCoordinateGenerator(TilesCoordinateGenerator):
         :param min_zoom: the minimum zoom(inclusive) it can generate tiles for
         :param max_zoom: the maximum zoom(inclusive) it can generate tiles for
         """
-        super(BoundingBoxTilesCoordinateGenerator, self).__init__(min_zoom=min_zoom, max_zoom=max_zoom)
+        super(BoundingBoxTileCoordinatesGenerator, self).__init__(min_zoom=min_zoom, max_zoom=max_zoom)
         self.min_x = min_x
         self.min_y = min_y
         self.max_x = max_x
@@ -72,5 +72,5 @@ class BoundingBoxTilesCoordinateGenerator(TilesCoordinateGenerator):
         """ Get the tiles overlapped by a geographic bounding box """
         for m_tile in tiles(self.min_x, self.min_y, self.max_x, self.max_y,
                             self.filter_zooms_in_range(zooms), True):
-            yield BoundingBoxTilesCoordinateGenerator.\
+            yield BoundingBoxTileCoordinatesGenerator.\
                 convert_mercantile(m_tile)

--- a/utils/tiles.py
+++ b/utils/tiles.py
@@ -1,0 +1,75 @@
+from ModestMaps.Core import Coordinate
+from mercantile import tiles
+from mercantile import tile
+from typing import Iterator
+from typing import List
+
+
+class TilesCoordinateGenerator(object):
+    """
+    Generate tiles EPSG:3857 coordinates from a list of zooms within a range
+    """
+    def __init__(self, min_zoom, max_zoom):
+        # type: (int, int) -> None
+        """
+        :param min_zoom: the minimum zoom(inclusive) it can generate tiles for
+        :param max_zoom: the maximum zoom(inclusive) it can generate tiles for
+        """
+        self.min_zoom = min_zoom
+        self.max_zoom = max_zoom
+
+    def filter_zooms_in_range(self, zooms):
+        # type: (List[int]) -> List[int]
+        """ given a list of zooms return zooms within min_zoom and max_zoom"""
+        if bool(zooms):
+            ranged_zoom = [z for z in zooms if
+                           self.min_zoom <= z <= self.max_zoom]
+        else:
+            ranged_zoom = [z for z in range(self.min_zoom, self.max_zoom+1)]
+        return ranged_zoom
+
+    def generate_tiles_coordinates(self, zooms):
+        # type: (List[int]) -> Iterator[Coordinate]
+        """ Generate all tiles coordinates in the specific zoom or
+        all tiles coordinates if zoom is empty"""
+
+        for zoom in self.filter_zooms_in_range(zooms):
+            max_coord = 2 ** zoom
+            for x in range(max_coord):
+                for y in range(max_coord):
+                    yield Coordinate(zoom=zoom, column=x, row=y)
+
+
+class BoundingBoxTilesCoordinateGenerator(TilesCoordinateGenerator):
+    """ Generate the tiles overlapped by a geographic bounding box within a
+    range """
+
+    # todo is 25 tilezen's max zoom????
+    def __init__(self, west, south, east, north, min_zoom=0, max_zoom=25):
+        # type: (float, float, float, float, int, int) -> None
+        """
+        :param west: longitude of the west boundary
+        :param south: latitude of the south boundary
+        :param east: longitude of the east boundary
+        :param north: latitude of the north boundary
+        :param min_zoom: the minimum zoom(inclusive) it can generate tiles for
+        :param max_zoom: the maximum zoom(inclusive) it can generate tiles for
+        """
+        super().__init__(min_zoom=min_zoom, max_zoom=max_zoom)
+        self.west = west
+        self.south = south
+        self.east = east
+        self.north = north
+
+    @staticmethod
+    def convert_mercantile(m_tile):
+        # type: (tile) -> Coordinate
+        return Coordinate(column=m_tile.x, row=m_tile.y, zoom=m_tile.z)
+
+    def generate_tiles_coordinates(self, zooms):
+        # type: (List[int]) -> Iterator[Coordinate]
+        """ Get the tiles overlapped by a geographic bounding box """
+        for m_tile in tiles(self.west, self.south, self.east, self.north,
+                            self.filter_zooms_in_range(zooms), True):
+            yield BoundingBoxTilesCoordinateGenerator.\
+                convert_mercantile(m_tile)

--- a/utils/tiles.py
+++ b/utils/tiles.py
@@ -1,8 +1,8 @@
 from ModestMaps.Core import Coordinate
 from mercantile import tiles
 from mercantile import tile
-from typing import Iterator
-from typing import List
+#from typing import Iterator
+#from typing import List
 from utils.constants import MAX_TILE_ZOOM
 from utils.constants import MIN_TILE_ZOOM
 

--- a/utils/tiles.py
+++ b/utils/tiles.py
@@ -3,6 +3,8 @@ from mercantile import tiles
 from mercantile import tile
 from typing import Iterator
 from typing import List
+from utils.constants import MAX_TILE_ZOOM
+from utils.constants import MIN_TILE_ZOOM
 
 
 class TilesCoordinateGenerator(object):
@@ -44,8 +46,8 @@ class BoundingBoxTilesCoordinateGenerator(TilesCoordinateGenerator):
     """ Generate the tiles overlapped by a geographic bounding box within a
     range """
 
-    # todo is 25 tilezen's max zoom????
-    def __init__(self, west, south, east, north, min_zoom=0, max_zoom=25):
+    def __init__(self, west, south, east, north, min_zoom=MIN_TILE_ZOOM,
+                 max_zoom=MAX_TILE_ZOOM):
         # type: (float, float, float, float, int, int) -> None
         """
         :param west: longitude of the west boundary


### PR DESCRIPTION
Add bounding box rebuild ability

### Background
After each global build, we might want to rebuild the area in a certain bounding box, so adding the ability to achieve that.


### Test
Triggered the build using a few bounding boxes and verified the tiles manually. 
