### PR TITLE
update instance type to standard m5.  4GB mem/cpu

### DIFF
--- a/batch-setup/batch_setup.py
+++ b/batch-setup/batch_setup.py
@@ -196,7 +196,7 @@ def batch_setup(region_name, run_id, vpc_id, securityGroupIds, computeEnvironmen
                 minvCpus=0,
                 maxvCpus=max_vcpus,
                 desiredvCpus=0,
-                instanceTypes=["r5"],
+                instanceTypes=["m5"],
                 # although this is called "instanceRole", it really wants an instance _profile_ ARN.
                 instanceRole=instanceProfileArn,
                 tags={


### PR DESCRIPTION
We don't need the 8GB/cpu R5's for these builds.  