### PR TITLE
Unify the zoom terminologies

### DIFF
--- a/batch-setup/make_meta_tiles.py
+++ b/batch-setup/make_meta_tiles.py
@@ -179,7 +179,7 @@ class MissingTileFinder(object):
 
             print("[make_meta_tiles] Splitting into high and low zoom lists")
 
-            # contains zooms 0 until group zoom. the jobs between the group
+            # contains zooms 0 until group_by_zoom. the jobs between the group
             # zoom and RAWR zoom are merged into the parent at group zoom.
             missing_low = CoordSet(max_zoom=queue_zoom)  # 7
 

--- a/batch-setup/make_meta_tiles.py
+++ b/batch-setup/make_meta_tiles.py
@@ -483,9 +483,6 @@ if __name__ == '__main__':
                 queue_zoom = low_zoom_tilequeue_config['batch']['queue-zoom']
                 group_by_zoom = low_zoom_tilequeue_config['rawr']['group-zoom']
 
-
-    # TODO: split zoom and zoom max should come from config.
-
     region = args.region or os.environ.get('AWS_DEFAULT_REGION')
     if region is None:
         print("[make_meta_tiles] ERROR: Need environment variable "


### PR DESCRIPTION
The tileops uses a few different names than that on tilequeue even though it calls the tilequeue for tile building; so rename some terminologies there to make them consistent.

The single source of the zoom values should all be from the config https://github.com/tilezen/tileops/blob/master/batch-setup/make_tiles.py#L163

This will make our V2 build easier too.