### PR TITLE
Add bbox build verification

### DIFF
--- a/batch-setup/cron.py
+++ b/batch-setup/cron.py
@@ -158,6 +158,7 @@ def create_tps_profile(iam, profile_name, locations):
                     'arn:aws:s3:::' + locations.missing.name,
                     'arn:aws:s3:::' + locations.assets.name,
                     'arn:aws:s3:::' + locations.rawr.name,
+                    'arn:aws:s3:::' + locations.meta.name,
                 ],
             ),
             dict(
@@ -170,6 +171,7 @@ def create_tps_profile(iam, profile_name, locations):
                     'arn:aws:s3:::' + locations.assets.name + assets_path,
                     'arn:aws:s3:::' + locations.missing.name + '/*',
                     'arn:aws:s3:::' + locations.rawr.name + '/*',
+                    'arn:aws:s3:::' + locations.meta.name + '/*',
                 ],
             ),
         ],

--- a/batch-setup/make_meta_tiles.py
+++ b/batch-setup/make_meta_tiles.py
@@ -25,7 +25,6 @@ from tilequeue.store import make_s3_tile_key_generator
 from ModestMaps.Core import Coordinate
 from multiprocessing import Pool
 from distutils.util import strtobool
-from utils.constants import MAX_TILE_ZOOM
 
 
 MissingTiles = namedtuple('MissingTiles', 'low_zoom_file high_zoom_file')

--- a/batch-setup/make_meta_tiles.py
+++ b/batch-setup/make_meta_tiles.py
@@ -179,7 +179,7 @@ class MissingTileFinder(object):
     @contextmanager
     def missing_tiles_split(self, group_by_zoom, queue_zoom, big_jobs,
                             try_generator):
-        # type: (int, int, CoordSet) -> Iterator[MissingTiles]
+        # type: (int, int, CoordSet, bool) -> Iterator[MissingTiles]
         """
         To be used in a with-statement. Yields a MissingTiles object, giving
         information about the tiles which are missing.
@@ -190,8 +190,7 @@ class MissingTileFinder(object):
         at queue_zoom.
         """
 
-        #tmpdir = tempfile.mkdtemp()
-        tmpdir = '/home/ec2-user/missingfile'
+        tmpdir = tempfile.mkdtemp()
         try:
             missing_low_file = os.path.join(tmpdir, 'missing.low.txt')
             missing_high_file = os.path.join(tmpdir, 'missing.high.txt')
@@ -254,8 +253,7 @@ class MissingTileFinder(object):
             yield MissingTiles(missing_low_file, missing_high_file)
 
         finally:
-            pass
-            #shutil.rmtree(tmpdir)
+            shutil.rmtree(tmpdir)
 
     @contextmanager
     def present_tiles(self):
@@ -572,8 +570,6 @@ if __name__ == '__main__':
         buckets.missing, buckets.meta, date_prefix, missing_bucket_date_prefix,
         region, args.key_format_type, args.config, metatile_max_zoom,
         generator, tile_verifier)
-
-    # tile_finder.test_tiles()
 
     big_jobs = _big_jobs(
         buckets.rawr, missing_bucket_date_prefix, args.key_format_type,

--- a/batch-setup/make_meta_tiles.py
+++ b/batch-setup/make_meta_tiles.py
@@ -8,10 +8,13 @@ from contextlib import contextmanager
 from collections import namedtuple
 import boto3
 import os
+import json
+import io
 import sys
 import shutil
 import tempfile
 from utils.tiles import BoundingBoxTileCoordinatesGenerator
+from utils.tiles import S3TileVerifier
 from tilequeue.tile import metatile_zoom_from_size
 from rds import ensure_dbs
 from tilequeue.tile import deserialize_coord
@@ -22,6 +25,7 @@ from tilequeue.store import make_s3_tile_key_generator
 from ModestMaps.Core import Coordinate
 from multiprocessing import Pool
 from distutils.util import strtobool
+from utils.constants import MAX_TILE_ZOOM
 
 
 MissingTiles = namedtuple('MissingTiles', 'low_zoom_file high_zoom_file')
@@ -36,7 +40,7 @@ class MissingTileFinder(object):
 
     def __init__(self, missing_bucket, tile_bucket, src_date_prefix,
                  dst_date_prefix, region, key_format_type, config, max_zoom,
-                 tile_coords_generator):
+                 tile_coords_generator, tile_verifier):
         self.missing_bucket = missing_bucket
         self.tile_bucket = tile_bucket
         self.src_date_prefix = src_date_prefix
@@ -45,6 +49,7 @@ class MissingTileFinder(object):
         self.key_format_type = key_format_type
         self.max_zoom = max_zoom
         self.tile_coords_generator = tile_coords_generator
+        self.tile_verifier = tile_verifier
 
         if not tile_coords_generator:
             assert self.missing_bucket
@@ -137,26 +142,40 @@ class MissingTileFinder(object):
                '-max-zoom', str(self.max_zoom),
                stdout=filename)
 
-    def generate_missing_tile_coords(self, try_generator=False):
-        # type: () -> List[Coordinate]
+    def generate_missing_tile_coords(self, tmpdir, try_generator=False):
+        # type: (File, bool) -> Generator[Union[Coordinate, str]]
         """ generate the missing tiles coordinates for low/high-zoom
             splitting
             :param try_generator: if set, it will to use the preset tile_coords_generator if that's available
         """
-        tmpdir = tempfile.mkdtemp()
-        try:
-            if try_generator and bool(self.tile_coords_generator):
-                print("[make_meta_tiles] generate missing tiles coords "
-                      "using customized generator")
-                return [coord for coord in self.tile_coords_generator.generate_tiles_coordinates([])]
-            else:
-                self.run_batch_job()
-                missing_meta_file = os.path.join(tmpdir, 'missing_meta.txt')
-                self.read_metas_to_file(missing_meta_file, compress=True)
-                with gzip.open(missing_meta_file, 'r') as fh:
-                    return [deserialize_coord(line) for line in fh]
-        finally:
-            shutil.rmtree(tmpdir)
+
+        if try_generator and bool(self.tile_coords_generator):
+            print("[make_meta_tiles] generate missing tiles coords "
+                    "using customized generator")
+            return self.tile_coords_generator.generate_tiles_coordinates([])
+        else:
+            self.run_batch_job()
+            missing_meta_file = os.path.join(tmpdir, 'missing_meta.txt')
+            self.read_metas_to_file(missing_meta_file, compress=True)
+            return gzip.open(missing_meta_file, 'r')
+
+    def test_tiles(self):
+        with open('/home/ec2-user/missingfile/missing.low.txt', 'r') as fh:
+            for fhcoord in fh:
+                coord = deserialize_coord(fhcoord)
+                self.tile_verifier.generate_tile_coords_rebuild_paths_low_zoom(
+                    job_coords=[coord],
+                    queue_zoom=queue_zoom,
+                    group_by_zoom=group_by_zoom)
+
+        with open('/home/ec2-user/missingfile/missing.high.txt', 'r') as fh:
+            for fhcoord in fh:
+                coord = deserialize_coord(fhcoord)
+                self.tile_verifier.generate_tile_coords_rebuild_paths_high_zoom(
+                    job_coords=[coord],
+                    queue_zoom=queue_zoom,
+                    group_by_zoom=group_by_zoom)
+
 
     @contextmanager
     def missing_tiles_split(self, group_by_zoom, queue_zoom, big_jobs,
@@ -172,7 +191,8 @@ class MissingTileFinder(object):
         at queue_zoom.
         """
 
-        tmpdir = tempfile.mkdtemp()
+        #tmpdir = tempfile.mkdtemp()
+        tmpdir = '/home/ec2-user/missingfile'
         try:
             missing_low_file = os.path.join(tmpdir, 'missing.low.txt')
             missing_high_file = os.path.join(tmpdir, 'missing.high.txt')
@@ -187,36 +207,56 @@ class MissingTileFinder(object):
             # queue_zoom is always less than or equal to group_by_zoom?
             missing_high = CoordSet(min_zoom=queue_zoom, max_zoom=group_by_zoom)
 
-            coords = self.generate_missing_tile_coords(try_generator)
-            for c in coords:
-                if c.zoom < group_by_zoom:  # 10
+
+            coords_or_file = self.generate_missing_tile_coords(tmpdir, try_generator)
+
+            for c in coords_or_file:
+                if isinstance(coords_or_file, io.IOBase):
+                    this_coord = deserialize_coord(c)
+                else:
+                    this_coord = c
+                if this_coord.zoom < group_by_zoom:  # 10
                     # in order to not have too many jobs in the queue, we
-                    # group the low zoom jobs to the queue_zoom (usually 7)
-                    if c.zoom > queue_zoom:  # 7
-                        c = c.zoomTo(queue_zoom).container()
-                    missing_low[c] = True
+                    # group the low zoom jobs to the zoom_max (usually 7)
+                    if this_coord.zoom > queue_zoom:  # 7
+                        this_coord = this_coord.zoomTo(queue_zoom).container()
+                    missing_low[this_coord] = True
                 else:
                     # if the group of jobs at queue_zoom would be too big
                     # (according to big_jobs[]) then enqueue the original
                     # coordinate. this is to prevent a "long tail" of huge
                     # job groups.
-                    job_coord = c.zoomTo(queue_zoom).container()  # 7
+                    job_coord = this_coord.zoomTo(queue_zoom).container()  # 7
                     if not big_jobs[job_coord]:
-                        c = job_coord
-                    missing_high[c] = True
+                        this_coord = job_coord
+                    missing_high[this_coord] = True
+
+            if isinstance(coords_or_file, io.IOBase):
+                coords_or_file.close()
 
             with open(missing_low_file, 'w') as fh:
                 for coord in missing_low:
                     fh.write(serialize_coord(coord) + "\n")
+                    if try_generator and self.tile_verifier is not None:
+                        self.tile_verifier.generate_tile_coords_rebuild_paths_low_zoom(
+                            job_coords=[coord],
+                            queue_zoom=queue_zoom,
+                            group_by_zoom=group_by_zoom)
 
             with open(missing_high_file, 'w') as fh:
                 for coord in missing_high:
                     fh.write(serialize_coord(coord) + "\n")
+                    if try_generator and self.tile_verifier is not None:
+                        self.tile_verifier.generate_tile_coords_rebuild_paths_high_zoom(
+                            job_coords=[coord],
+                            queue_zoom=queue_zoom,
+                            group_by_zoom=group_by_zoom)
 
             yield MissingTiles(missing_low_file, missing_high_file)
 
         finally:
-            shutil.rmtree(tmpdir)
+            pass
+            #shutil.rmtree(tmpdir)
 
     @contextmanager
     def present_tiles(self):
@@ -327,6 +367,7 @@ def enqueue_tiles(config_file, tile_list_file, check_metatile_exists,
     with open(args.config) as fh:
         cfg = make_config_from_argparse(fh)
 
+    print('[make_meta_tiles] zoom_stop ' + str(cfg.max_zoom))
     update_memory_request(cfg, mem_multiplier, mem_max)
     tilequeue_batch_enqueue(cfg, args)
 
@@ -363,7 +404,7 @@ class LowZoomLense(object):
 class TileRenderer(object):
 
     def __init__(self, tile_finder, big_jobs, group_by_zoom, queue_zoom,
-                 allowed_missing_tiles=0, tile_coords_generator=None):
+                 tile_coords_generator, allowed_missing_tiles=0):
         self.tile_finder = tile_finder
         self.big_jobs = big_jobs
         self.group_by_zoom = group_by_zoom
@@ -376,6 +417,8 @@ class TileRenderer(object):
             self.group_by_zoom, self.queue_zoom, self.big_jobs, try_generator)
 
     def render(self, num_retries, lense):
+        """ Render the meta tiles and return a boolean indicates whether
+        this build is skipped due to allow threshold"""
         mem_max = 32 * 1024  # 32 GiB
 
         for retry_number in range(0, num_retries):
@@ -391,7 +434,7 @@ class TileRenderer(object):
                           "tiles, %d allowed. e.g. %s" %
                           (lense.description, count, self.allowed_missing_tiles,
                            ', '.join(sample)))
-                    break
+                    return try_generator  # only when we use generator can this return True (try_generator) value
 
                 check_metatile_exists = retry_number > 0
 
@@ -414,6 +457,7 @@ class TileRenderer(object):
                     "tries (e.g. %s)"
                     % (count, lense.description, num_retries,
                        ', '.join(sample)))
+        return False
 
 
 if __name__ == '__main__':
@@ -494,7 +538,15 @@ if __name__ == '__main__':
     assert args.metatile_size < 100
     metatile_max_zoom = 16 - metatile_zoom_from_size(args.metatile_size)
 
+    def _extract_s3_buckets_args(json_list):
+        buckets = json.loads(json_list)
+        assert type(buckets) == list
+        assert len(buckets) == 1
+        buckets_str = [b.encode('utf-8') for b in buckets]
+        return buckets_str[0]
+
     generator = None
+    tile_verifier = None
     if args.use_tile_coords_generator:
         bboxes = args.tile_coords_generator_bbox.split(',')
         assert len(bboxes) == 4, 'Seed config: custom bbox {} does not have exactly four elements!'.format(bboxes)
@@ -505,23 +557,48 @@ if __name__ == '__main__':
                                                         min_y=min_y,
                                                         max_x=max_x,
                                                         max_y=max_y)
+
+        tile_verifier = S3TileVerifier(date_prefix,
+                                       args.key_format_type,
+                                       '',
+                                       _extract_s3_buckets_args(buckets.meta),
+                                       '',
+                                       'high_zoom_s3_paths.csv',
+                                       'low_zoom_s3_paths.csv')
+
         print("[make_meta_tiles] Rebuild using bbox: " + args.tile_coords_generator_bbox)
+
 
     tile_finder = MissingTileFinder(
         buckets.missing, buckets.meta, date_prefix, missing_bucket_date_prefix,
-        region, args.key_format_type, args.config, metatile_max_zoom, generator)
+        region, args.key_format_type, args.config, metatile_max_zoom,
+        generator, tile_verifier)
+
+    # tile_finder.test_tiles()
 
     big_jobs = _big_jobs(
         buckets.rawr, missing_bucket_date_prefix, args.key_format_type,
         group_by_zoom, queue_zoom, args.size_threshold)
 
     tile_renderer = TileRenderer(tile_finder, big_jobs, group_by_zoom,
-                                 queue_zoom, args.allowed_missing_tiles,
-                                 generator)
+                                 queue_zoom, generator,
+                                 args.allowed_missing_tiles)
 
-    tile_renderer.render(args.retries, LowZoomLense(args.low_zoom_config))
+    is_low_break = tile_renderer.render(args.retries, LowZoomLense(args.low_zoom_config))
+    if args.use_tile_coords_generator and tile_verifier is not None:
+        if not is_low_break:
+            tile_verifier.verify_tiles_rebuild_time('meta_low_zoom')
+        else:
+            print('[make_meta_tiles] no need to verify low_zoom tiles rebuild '
+                  'time since it was skipped')
 
-    # turn off databases by saying we want to ensure that zero are running.
+    #turn off databases by saying we want to ensure that zero are running.
     ensure_dbs(args.run_id, 0)
 
-    tile_renderer.render(args.retries, HighZoomLense(args.high_zoom_config))
+    is_high_break = tile_renderer.render(args.retries, HighZoomLense(args.high_zoom_config))
+    if args.use_tile_coords_generator and tile_verifier is not None:
+        if not is_high_break:
+            tile_verifier.verify_tiles_rebuild_time('meta_high_zoom')
+        else:
+            print('[make_meta_tiles] no need to verify high_zoom tiles '
+                  'rebuild time since it was skipped')

--- a/batch-setup/make_meta_tiles.py
+++ b/batch-setup/make_meta_tiles.py
@@ -158,24 +158,6 @@ class MissingTileFinder(object):
             self.read_metas_to_file(missing_meta_file, compress=True)
             return gzip.open(missing_meta_file, 'r')
 
-    def test_tiles(self):
-        with open('/home/ec2-user/missingfile/missing.low.txt', 'r') as fh:
-            for fhcoord in fh:
-                coord = deserialize_coord(fhcoord)
-                self.tile_verifier.generate_tile_coords_rebuild_paths_low_zoom(
-                    job_coords=[coord],
-                    queue_zoom=queue_zoom,
-                    group_by_zoom=group_by_zoom)
-
-        with open('/home/ec2-user/missingfile/missing.high.txt', 'r') as fh:
-            for fhcoord in fh:
-                coord = deserialize_coord(fhcoord)
-                self.tile_verifier.generate_tile_coords_rebuild_paths_high_zoom(
-                    job_coords=[coord],
-                    queue_zoom=queue_zoom,
-                    group_by_zoom=group_by_zoom)
-
-
     @contextmanager
     def missing_tiles_split(self, group_by_zoom, queue_zoom, big_jobs,
                             try_generator):

--- a/batch-setup/make_rawr_tiles.py
+++ b/batch-setup/make_rawr_tiles.py
@@ -90,7 +90,7 @@ def missing_jobs(missing_bucket, rawr_bucket, date_prefix, region, config,
 
     tmpdir = tempfile.mkdtemp()
     try:
-        missing_file = os.path.join('/home/ec2-user/missingfile', "missing_jobs.txt")
+        missing_file = os.path.join(tmpdir, "missing_jobs.txt")
 
         with open(missing_file, 'w') as fh:
             for coord in sorted(job_coords):

--- a/utils/tiles.py
+++ b/utils/tiles.py
@@ -276,4 +276,4 @@ class S3TileVerifier(object):
             print('all {tile_type} tiles successfully verified'.format(
                 tile_type=tile_type))
         else:
-            print('{tile_type} tiles failed to be verified.')
+            print('{tile_type} tiles failed to be verified.'.format(tile_type=tile_type))

--- a/utils/tiles.py
+++ b/utils/tiles.py
@@ -23,7 +23,7 @@ class TileCoordinatesGenerator(object):
         self.min_zoom = min_zoom
         self.max_zoom = max_zoom
 
-    def filter_zooms_in_range(self, zooms):
+    def filter_zooms_in_range(self, zooms=None):
         # type: (List[int]) -> List[int]
         """ given a list of zooms return zooms within min_zoom and max_zoom"""
         if bool(zooms):
@@ -33,7 +33,7 @@ class TileCoordinatesGenerator(object):
             ranged_zoom = [z for z in range(self.min_zoom, self.max_zoom+1)]
         return ranged_zoom
 
-    def generate_tiles_coordinates(self, zooms):
+    def generate_tiles_coordinates(self, zooms=None):
         # type: (List[int]) -> Iterator[Coordinate]
         """ Generate all tiles coordinates in the specific zoom or
         all tiles coordinates if zoom is empty"""
@@ -71,7 +71,7 @@ class BoundingBoxTileCoordinatesGenerator(TileCoordinatesGenerator):
         # type: (tile) -> Coordinate
         return Coordinate(column=m_tile.x, row=m_tile.y, zoom=m_tile.z)
 
-    def generate_tiles_coordinates(self, zooms):
+    def generate_tiles_coordinates(self, zooms=None):
         # type: (List[int]) -> Iterator[Coordinate]
         """ Get the tiles overlapped by a geographic bounding box """
         for m_tile in tiles(self.min_x, self.min_y, self.max_x, self.max_y,
@@ -117,7 +117,7 @@ class S3TileVerifier(object):
         self.rawr_s3_bucket = rawr_s3_bucket
         self.meta_s3_bucket = meta_s3_bucket
 
-    # https://github.com/tilezen/tilequeue/blob/9644d916a864bd7d97448c40823158016e5e6dd2/tilequeue/command.py#L1861
+    # The tile coords expansion logic mimics https://github.com/tilezen/tilequeue/blob/9644d916a864bd7d97448c40823158016e5e6dd2/tilequeue/command.py#L1861
     def generate_tile_coords_rebuild_paths_rawr(self, job_coords, group_by_zoom):
         """
         Generate the s3 paths of the rawr tiles that need to be rebuilt.

--- a/utils/tiles.py
+++ b/utils/tiles.py
@@ -1,8 +1,14 @@
 from ModestMaps.Core import Coordinate
 from mercantile import tiles
 from mercantile import tile
+import boto3
 from utils.constants import MAX_TILE_ZOOM
 from utils.constants import MIN_TILE_ZOOM
+from tilequeue.store import S3TileKeyGenerator
+from tilequeue.store import KeyFormatType
+from tilequeue.store import make_s3_tile_key_generator
+from tilequeue.command import find_job_coords_for
+from tilequeue.tile import coord_children_range
 
 
 class TileCoordinatesGenerator(object):
@@ -74,3 +80,191 @@ class BoundingBoxTileCoordinatesGenerator(TileCoordinatesGenerator):
                             self.filter_zooms_in_range(zooms), True):
             yield BoundingBoxTileCoordinatesGenerator.\
                 convert_mercantile(m_tile)
+
+
+class S3TileVerifier(object):
+    """
+    Used the logic of tilequeue to expand tile coordinates to the rawr and meta
+    tiles S3 locations that tilequeue would write to.
+
+    It is useful for arbitrary tile build verification because we can use the
+    methods provided here to pre-generate the s3 objects' paths that we need
+    to verify later.
+    """
+
+    def __init__(self,
+                 date_prefix,
+                 key_format_type_str,
+                 rawr_s3_bucket,
+                 meta_s3_bucket,
+                 rawr_tile_filename,
+                 high_zoom_tile_filename,
+                 low_zoom_tile_filename):
+        # type: (str, str, str, str, str, str, str) -> None
+        """
+        :param date_prefix: the minimum zoom(inclusive) it can generate tiles for
+        :param key_format_type_str: the maximum zoom(inclusive) it can generate tiles for
+        :param rawr_tile_filename: the maximum zoom(inclusive) it can generate tiles for
+        :param high_zoom_tile_filename: the maximum zoom(inclusive) it can generate tiles for
+        :param low_zoom_tile_filename: the maximum zoom(inclusive) it can generate tiles for
+        """
+        self.date_prefix = date_prefix
+        self.key_format_type_str = key_format_type_str
+        self.rawr_tile_filename = rawr_tile_filename
+        self.high_zoom_tile_filename = high_zoom_tile_filename
+        self.low_zoom_tile_filename = low_zoom_tile_filename
+        self.s3 = boto3.client('s3')
+        self.rawr_s3_bucket = rawr_s3_bucket
+        self.meta_s3_bucket = meta_s3_bucket
+
+    # https://github.com/tilezen/tilequeue/blob/9644d916a864bd7d97448c40823158016e5e6dd2/tilequeue/command.py#L1861
+    def generate_tile_coords_rebuild_paths_rawr(self, job_coords, group_by_zoom):
+        """
+        Used when tile_coords_generator is used. It will return the s3 paths
+        of the tiles that need to be rebuilt.
+
+        Note: we could have directly print out the paths without needing to
+        call tilequeue.command.find_job_coords_for
+        because the current setup hardcodes target_zoom to be 10 in both
+        tilequeue and here in tileops.
+        However that is too weak a contract which may be broken one day,
+        so for future safety,
+        we calls find_job_coords_for method to print out the tile paths.
+        """
+        job_coords_int = [Coordinate(int(jc.row), int(jc.column), int(jc.zoom))
+                          for jc in job_coords]
+        extension = 'zip'  # TODO: for now this should match the one defined
+        s3_key_gen = make_s3_tile_key_generator({
+            'key-format-type': self.key_format_type_str,
+        })
+        all_coords_paths = []  # type: List[str]
+        for coord in job_coords_int:
+            # TODO: write to a file to not use to much memory
+            coords_paths = [s3_key_gen(self.date_prefix, c, extension) for c in
+                            find_job_coords_for(coord, group_by_zoom)]
+            all_coords_paths.extend(coords_paths)
+
+        with open(self.rawr_tile_filename, 'a') as fh:
+            for path in all_coords_paths:
+                response = self.s3.head_object(
+                    Bucket=self.rawr_s3_bucket,
+                    Key=path
+                )
+                datetime_value = response["LastModified"]
+                fh.write(path + "," + datetime_value.strftime("%Y-%m-%dT%H:%M:%S%z") + "\n")
+
+        return all_coords_paths
+
+    def verify_tiles_rebuild_time(self, tile_type):
+        all_verified = True
+        if tile_type == 'rawr':
+            file_name = self.rawr_tile_filename
+            bucket = self.rawr_s3_bucket
+        elif tile_type == 'meta_high_zoom':
+            file_name = self.high_zoom_tile_filename
+            bucket = self.meta_s3_bucket
+        elif tile_type == 'meta_low_zoom':
+            file_name = self.low_zoom_tile_filename
+            bucket = self.meta_s3_bucket
+        else:
+            raise Exception('tile_type:{tt} is not supported.'.format(tt=tile_type))
+
+        print('verifying {tile_type} tiles rebulid time...'.format(tile_type=tile_type))
+        with open(file_name, 'r') as fh:
+            for line in fh:
+                elements = line.rstrip().split(',')
+                assert len(elements) == 2
+                s3_key_path = elements[0]
+                modified_time_before_rebuild = elements[1]
+                try:
+                    response = self.s3.head_object(
+                        Bucket=bucket,
+                        Key=s3_key_path
+                    )
+                    datetime_value = response['LastModified']
+                    datetime_str = datetime_value.strftime('%Y-%m-%dT%H:%M:%S%z')
+                    assert datetime_str > modified_time_before_rebuild, '{tile_type} {key} new time:{new_time} is not newer than old time:{old_time}'.format(tile_type=tile_type, key=s3_key_path, new_time=datetime_str, old_time=modified_time_before_rebuild)
+                except Exception as e:
+                    print('exceptions encountered during verifying {tile_type} tile object:{path} exception:{e}'.format(tile_type=tile_type, path=s3_key_path, e=e))
+                    all_verified = False
+        if all_verified:
+            print('all {tile_type} tiles successfully verified'.format(tile_type=tile_type))
+        else:
+            print('{tile_type} tiles failed to be verified.')
+
+    # The tile expansion logic references
+    # https://github.com/tilezen/tilequeue/blob/9644d916a864bd7d97448c40823158016e5e6dd2/tilequeue/command.py#L2074
+    def generate_tile_coords_rebuild_paths_high_zoom(self, job_coords, queue_zoom, group_by_zoom):
+        job_coords_int = [Coordinate(int(jc.row), int(jc.column), int(jc.zoom))
+                          for jc in job_coords]
+        zoom_stop = 13
+        assert zoom_stop > group_by_zoom, 'zoom_stop is not greater than ' \
+                                          'group_by_zoom'
+
+        s3_key_gen = make_s3_tile_key_generator({
+            'key-format-type': self.key_format_type_str,
+        })
+
+        extension = 'zip'
+        all_coords = []
+        for job_coord_int in job_coords_int:
+            assert queue_zoom <= job_coord_int.zoom <= group_by_zoom, \
+                'Unexpected zoom: %d, zoom should be between %d and %d' % (
+                job_coord_int.zoom, queue_zoom, group_by_zoom)
+            more_job_coords = find_job_coords_for(job_coord_int, group_by_zoom)
+            for mjc in more_job_coords:
+                pyramid_coords = [mjc]
+                pyramid_coords.extend(coord_children_range(mjc, zoom_stop))
+                all_coords.extend(pyramid_coords)
+
+        all_coords_paths = [s3_key_gen(self.date_prefix, c, extension) for c in
+                            all_coords]
+
+        with open(self.high_zoom_tile_filename, 'a') as fh:
+            for path in all_coords_paths:
+                response = self.s3.head_object(
+                    Bucket=self.meta_s3_bucket,
+                    Key=path
+                )
+                datetime_value = response["LastModified"]
+                fh.write(path + "," + datetime_value.strftime("%Y-%m-%dT%H:%M:%S%z") + "\n")
+
+        return all_coords_paths
+
+
+    # The tile expansion logic references
+    # https://github.com/tilezen/tilequeue/blob/9644d916a864bd7d97448c40823158016e5e6dd2/tilequeue/command.py#L2199
+    def generate_tile_coords_rebuild_paths_low_zoom(self,
+                                                    job_coords,
+                                                    queue_zoom,
+                                                    group_by_zoom):
+        assert queue_zoom < group_by_zoom, 'queue_zoom is not less than ' \
+                                           'group_by_zoom'
+        job_coords_int = [Coordinate(int(jc.row), int(jc.column), int(jc.zoom))
+                          for jc in job_coords]
+
+        s3_key_gen = make_s3_tile_key_generator({
+            'key-format-type': self.key_format_type_str,
+        })
+
+        extension = 'zip'
+        coords = []
+
+        for job_coord_int in job_coords_int:
+            assert 0 <= job_coord_int.zoom <= queue_zoom
+            if job_coord_int.zoom == queue_zoom and job_coord_int.zoom < \
+                    group_by_zoom - 1:
+                coords.extend(
+                    coord_children_range(job_coord_int, group_by_zoom - 1))
+
+        all_coords_paths = [s3_key_gen(self.date_prefix, c, extension) for c in
+                            coords]
+        with open(self.low_zoom_tile_filename, 'a') as fh:
+            for path in all_coords_paths:
+                response = self.s3.head_object(
+                    Bucket=self.meta_s3_bucket,
+                    Key=path
+                )
+                datetime_value = response["LastModified"]
+                fh.write(path + "," + datetime_value.strftime("%Y-%m-%dT%H:%M:%S%z") + "\n")
+        return all_coords_paths


### PR DESCRIPTION
## Background
Add a verification step after the bounding box build step to verify all the s3 object (tiles) that should be updated are actually updated.

## Changes
1. Add the meta tiles s3 bucket to the inline policy of the tileops so that the script has the permission to list and get meta tiles objects
2. Change the implementation of `generate_missing_tile_coords` to return generator instead of set of coordinates strings since it may be too large to fit into memory
2. Add the implementation of tiles generate and verification to a class S3TileVerififier and use it to do tiles s3 object updated time verification
