### PR TITLE
adding hanzidentifier to the batch job defs

### DIFF
--- a/docker/meta-batch/requirements.txt
+++ b/docker/meta-batch/requirements.txt
@@ -27,4 +27,5 @@ zope.dottedname==4.2
 edtf==2.6.0
 mapbox-vector-tile==1.2.0
 boto3==1.7.10
+hanzidentifier==1.0.2
 git+https://github.com/tilezen/coanacatl@v0.5.0#egg=coanacatl

--- a/docker/meta-low-zoom-batch/requirements.txt
+++ b/docker/meta-low-zoom-batch/requirements.txt
@@ -27,4 +27,5 @@ zope.dottedname==4.2
 edtf==2.6.0
 mapbox-vector-tile==1.2.0
 boto3==1.7.10
+hanzidentifier==1.0.2
 git+https://github.com/tilezen/coanacatl@v0.5.0#egg=coanacatl

--- a/docker/rawr-batch/requirements.txt
+++ b/docker/rawr-batch/requirements.txt
@@ -27,3 +27,4 @@ zope.dottedname==4.2
 edtf==2.6.0
 mapbox-vector-tile==1.2.0
 boto3==1.7.10
+hanzidentifier==1.0.2

--- a/docker/rawr-batch/requirements.txt
+++ b/docker/rawr-batch/requirements.txt
@@ -27,4 +27,3 @@ zope.dottedname==4.2
 edtf==2.6.0
 mapbox-vector-tile==1.2.0
 boto3==1.7.10
-hanzidentifier==1.0.2


### PR DESCRIPTION
We updated this in vector-datasource, but neglected to in tileops.