### PR TITLE
Increase the amount of disk space for the osm2pgsql RDS instance

### DIFF
--- a/import/database.py
+++ b/import/database.py
@@ -90,7 +90,7 @@ def ensure_database(run_id, master_user_password):
             DBName='gis',
             DBInstanceIdentifier=instance_id,
             AllocatedStorage=2500,
-            DBInstanceClass='db.m6g.4xlarge',
+            DBInstanceClass='db.m6g.8xlarge',
             Engine='postgres',
             MasterUsername='gisuser',
             MasterUserPassword=master_user_password,

--- a/import/database.py
+++ b/import/database.py
@@ -89,7 +89,7 @@ def ensure_database(run_id, master_user_password):
         rds.create_db_instance(
             DBName='gis',
             DBInstanceIdentifier=instance_id,
-            AllocatedStorage=1600,
+            AllocatedStorage=2500,
             DBInstanceClass='db.m6g.4xlarge',
             Engine='postgres',
             MasterUsername='gisuser',


### PR DESCRIPTION
Bump the disk space given to the osm2pgsql instance from 1600GB to 2500GB, since we were running out of space.

I also switched from a m6g.4xl to a m6g.8xl to get [`12 Gbps` networking instead of `Up to 10Gbps`](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Concepts.DBInstanceClass.html).