### PR TITLE
Fix bbox script

### DIFF
--- a/batch-setup/provision.sh
+++ b/batch-setup/provision.sh
@@ -153,11 +153,11 @@ set -e
 # echo commands before executing them (useful to check that the arguments are correct)
 set -x
 
-python -u /usr/local/src/tileops/batch-setup/make_tiles.py --num-db-replicas $NUM_DB_REPLICAS --max-vcpus $MAX_VCPUS $RUN_ID --missing-bucket $MISSING_BUCKET --meta-date-prefix $META_DATE_PREFIX $RAWR_BUCKET $META_BUCKET $DB_PASSWORD --overrides $JOB_ENV_OVERRIDES
+python -u /usr/local/src/tileops/batch-setup/make_tiles.py --num-db-replicas \$NUM_DB_REPLICAS --max-vcpus \$MAX_VCPUS \$RUN_ID --missing-bucket \$MISSING_BUCKET --meta-date-prefix \$META_DATE_PREFIX \$RAWR_BUCKET \$META_BUCKET \$DB_PASSWORD --overrides \$JOB_ENV_OVERRIDES
 
-python -u /usr/local/src/tileops/batch-setup/make_rawr_tiles.py --config enqueue-rawr-batch.config.yaml --key-format-type hash-prefix --use-tile-coords-generator --tile-coords-generator-bbox=$BBOX $RAWR_BUCKET $RUN_ID $MISSING_BUCKET
+python -u /usr/local/src/tileops/batch-setup/make_rawr_tiles.py --config enqueue-rawr-batch.config.yaml --key-format-type hash-prefix --use-tile-coords-generator --tile-coords-generator-bbox=\$BBOX \$RAWR_BUCKET \$RUN_ID \$MISSING_BUCKET
 
-python -u /usr/local/src/tileops/batch-setup/make_meta_tiles.py --date-prefix $META_DATE_PREFIX --missing-bucket $MISSING_BUCKET --key-format-type hash-prefix --metatile-size $METATILE_SIZE --use-tile-coords-generator --tile-coords-generator-bbox=$BBOX $RAWR_BUCKET $META_BUCKET $RUN_ID
+python -u /usr/local/src/tileops/batch-setup/make_meta_tiles.py --date-prefix \$META_DATE_PREFIX --missing-bucket \$MISSING_BUCKET --key-format-type hash-prefix --metatile-size \$METATILE_SIZE --use-tile-coords-generator --tile-coords-generator-bbox=\$BBOX \$RAWR_BUCKET \$META_BUCKET \$RUN_ID
 EOF
 chmod +x /usr/local/bin/bbox_rebuild.sh
 


### PR DESCRIPTION
The bounding box script's environment variables need escape, so fixing that.

@tilezen/tilezen-team 