### PR TITLE
Plumb flag to skip post-import steps

### DIFF
--- a/batch-setup/cron.py
+++ b/batch-setup/cron.py
@@ -530,7 +530,6 @@ if __name__ == '__main__':
                         'file for the OSM planet file specified by the '
                         'planet-url argument.')
     parser.add_argument('--skip-post-import-steps', dest='run_post_import_steps', action='store_false')
-    parser.set_defaults(run_post_import_steps=True)
 
     args = parser.parse_args()
     assert_run_id_format(args.run_id)

--- a/batch-setup/cron.py
+++ b/batch-setup/cron.py
@@ -529,6 +529,8 @@ if __name__ == '__main__':
                         '<planet-url>.md5 convention to specify an md5 '
                         'file for the OSM planet file specified by the '
                         'planet-url argument.')
+    parser.add_argument('--skip-post-import-steps', dest='run_post_import_steps', action='store_false')
+    parser.set_defaults(run_post_import_steps=True)
 
     args = parser.parse_args()
     assert_run_id_format(args.run_id)
@@ -624,6 +626,7 @@ if __name__ == '__main__':
         job_env_overrides=" ".join(args.job_env_overrides),
         num_db_replicas=args.num_db_replicas,
         max_vcpus=args.max_vcpus,
+        run_post_import_steps=args.run_post_import_steps,
     )
 
     script_dir = os.path.dirname(os.path.realpath(__file__))

--- a/batch-setup/provision.sh
+++ b/batch-setup/provision.sh
@@ -129,11 +129,12 @@ set -e
 set -x
 
 if [ "$RUN_POST_IMPORT_STEPS" = "False" ]; then
-  echo "Warning: Will skip post import steps!"
+  echo "Warning: Will skip all post-import steps!"
+  SKIP_SNAPSHOT_ARG='--skip-snapshot'
 fi;
 
 python -u /usr/local/src/tileops/import/import.py --find-ip-address meta --planet-url \$PLANET_URL --planet-md5-url \$PLANET_MD5_URL --run-id \$RUN_ID --vector-datasource-version \$VECTOR_DATASOURCE_VERSION \$TILE_ASSET_BUCKET \$AWS_DEFAULT_REGION \
-       \$TILE_ASSET_PROFILE_ARN \$DB_PASSWORD
+       \$TILE_ASSET_PROFILE_ARN \$DB_PASSWORD \$SKIP_SNAPSHOT_ARG
 
 if [ "$RUN_POST_IMPORT_STEPS" = "True" ]; then
   python -u /usr/local/src/tileops/batch-setup/make_tiles.py --num-db-replicas \$NUM_DB_REPLICAS \


### PR DESCRIPTION
Need a way from cron.py to skip everything post-import. 
@iandees need your eyeballs to vet my scriptfu.
@peitili I need your eyeballs to make sure I'm passing the --skip-snapshot flag the way you intended.