### PR TITLE
Add flag to not terminate osm2pgsql runner

### DIFF
--- a/batch-setup/cron.py
+++ b/batch-setup/cron.py
@@ -529,7 +529,15 @@ if __name__ == '__main__':
                         '<planet-url>.md5 convention to specify an md5 '
                         'file for the OSM planet file specified by the '
                         'planet-url argument.')
-    parser.add_argument('--skip-post-import-steps', dest='run_post_import_steps', action='store_false')
+    parser.add_argument('--skip-post-import-steps',
+                        dest='run_post_import_steps',
+                        action='store_false',
+                        help='Whether to skip the snapshot creation and '
+                             'instance deletion')
+    parser.add_argument('--skip-osm2pgsql-instance-shutdown', default=False,
+                        action='store_true',
+                        help='Whether to skip terminating the osm2pgsql EC2 '
+                             'instance after the osm2pgsql import')
 
     args = parser.parse_args()
     assert_run_id_format(args.run_id)
@@ -626,6 +634,7 @@ if __name__ == '__main__':
         num_db_replicas=args.num_db_replicas,
         max_vcpus=args.max_vcpus,
         run_post_import_steps=args.run_post_import_steps,
+        skip_osm2pgsql_instance_shutdown=args.skip_osm2pgsql_instance_shutdown,
     )
 
     script_dir = os.path.dirname(os.path.realpath(__file__))

--- a/batch-setup/provision.sh
+++ b/batch-setup/provision.sh
@@ -98,6 +98,7 @@ export METATILE_SIZE='%(metatile_size)d'
 export NUM_DB_REPLICAS='%(num_db_replicas)d'
 export MAX_VCPUS='%(max_vcpus)d'
 export RUN_POST_IMPORT_STEPS='%(run_post_import_steps)s'
+export SKIP_OSM2PGSQL_INSTANCE_SHUTDOWN='%(skip_osm2pgsql_instance_shutdown)s'
 export JOB_ENV_OVERRIDES='%(job_env_overrides)s'
 eof
 
@@ -133,8 +134,13 @@ if [ "\$RUN_POST_IMPORT_STEPS" = "False" ]; then
   SKIP_SNAPSHOT_ARG='--skip-snapshot'
 fi;
 
+if [ "\SKIP_OSM2PGSQL_INSTANCE_SHUTDOWN" = "True" ]; then
+  echo "Warning: Will skip the termination of osm2pgsql instance!"
+  SKIP_OSM2PGSQL_INSTANCE_SHUTDOWN_ARG='--skip-osm2pgsql-instance-shutdown'
+fi;
+
 python -u /usr/local/src/tileops/import/import.py --find-ip-address meta --planet-url \$PLANET_URL --planet-md5-url \$PLANET_MD5_URL --run-id \$RUN_ID --vector-datasource-version \$VECTOR_DATASOURCE_VERSION \$TILE_ASSET_BUCKET \$AWS_DEFAULT_REGION \
-       \$TILE_ASSET_PROFILE_ARN \$DB_PASSWORD \$SKIP_SNAPSHOT_ARG
+       \$TILE_ASSET_PROFILE_ARN \$DB_PASSWORD \$SKIP_SNAPSHOT_ARG \$SKIP_OSM2PGSQL_INSTANCE_SHUTDOWN_ARG
 
 if [ "\$RUN_POST_IMPORT_STEPS" = "True" ]; then
   python -u /usr/local/src/tileops/batch-setup/make_tiles.py --num-db-replicas \$NUM_DB_REPLICAS \

--- a/import/import.py
+++ b/import/import.py
@@ -69,6 +69,10 @@ parser.add_argument('--run-id', help='Distinctive run ID to give to '
 parser.add_argument('--skip-snapshot', default=False, action='store_true',
                     help='Whether to skip the snapshot creation and instance '
                          'deletion')
+parser.add_argument('--skip-osm2pgsql-instance-shutdown', default=False,
+                    action='store_true',
+                    help='Whether to skip terminating the osm2pgsql EC2 '
+                         'instance after the osm2pgsql import')
 
 args = parser.parse_args()
 
@@ -124,7 +128,8 @@ else:
 
 osm2pgsql.ensure_import(
     run_id, planet_url, planet_md5_url, planet_file, db, getattr(args, 'iam-instance-profile'),
-    args.bucket, args.region, ip_addr, args.vector_datasource_version)
+    args.bucket, args.region, ip_addr, args.vector_datasource_version,
+    args.skip_osm2pgsql_instance_shutdown)
 
 if not args.skip_snapshot:
     database.take_snapshot_and_shutdown(db, run_id)

--- a/import/osm2pgsql.py
+++ b/import/osm2pgsql.py
@@ -436,7 +436,8 @@ def shutdown_and_cleanup(ec2, import_instance_id, run_id, ip_addr):
 def ensure_import(
         run_id, planet_url, planet_md5_url, planet_file,
         db, iam_instance_profile, bucket, aws_region, ip_addr,
-        vector_datasource_version='master'):
+        vector_datasource_version='master',
+        skip_osm2pgsql_instance_shutdown=False):
     ec2 = boto3.client('ec2')
 
     # is there already an import instance running?
@@ -517,4 +518,5 @@ def ensure_import(
             vector_datasource_version=vector_datasource_version,
         )
 
-    #shutdown_and_cleanup(ec2, import_instance_id, run_id, ip_addr)
+    if not skip_osm2pgsql_instance_shutdown:
+        shutdown_and_cleanup(ec2, import_instance_id, run_id, ip_addr)

--- a/import/osm2pgsql.py
+++ b/import/osm2pgsql.py
@@ -517,4 +517,4 @@ def ensure_import(
             vector_datasource_version=vector_datasource_version,
         )
 
-    shutdown_and_cleanup(ec2, import_instance_id, run_id, ip_addr)
+    #shutdown_and_cleanup(ec2, import_instance_id, run_id, ip_addr)


### PR DESCRIPTION
We sometimes don't want the osm2pgsql runner to be terminated after import when want to do a DB modifications directly on that runner instance later, thus we add the flag for that.

The implementation mechanism is similar to `--skip-post-import-steps` flag