### PR TITLE
Upgrading to new, faster osm2pgsql

### DIFF
--- a/import/import_planet.sh
+++ b/import/import_planet.sh
@@ -74,7 +74,6 @@ sudo DEBIAN_FRONTEND=noninteractive apt install -y -q make g++ git awscli build-
 # install osm2pgsql from PPA
 if [[ ! -x $OSM2PGSQL ]]; then
     echo "installing osm2pgsql" > $STATUS
-    sudo DEBIAN_FRONTEND=noninteractive apt-add-repository -y ppa:tilezen/ppa
     sudo DEBIAN_FRONTEND=noninteractive apt update
     sudo DEBIAN_FRONTEND=noninteractive apt install -y -q osm2pgsql
 fi

--- a/import/import_planet.sh
+++ b/import/import_planet.sh
@@ -69,7 +69,7 @@ trap stop_with_failure ERR
 echo "installing software" > $STATUS
 sudo DEBIAN_FRONTEND=noninteractive apt update
 sudo DEBIAN_FRONTEND=noninteractive apt upgrade -y -q
-sudo DEBIAN_FRONTEND=noninteractive apt install -y -q make g++ git awscli build-essential autoconf libtool pkg-config python-dev python-virtualenv python-pip python-pil libxml2-dev libxslt-dev unzip postgis osm2pgsql
+sudo DEBIAN_FRONTEND=noninteractive apt install -y -q make g++ git awscli build-essential autoconf libtool pkg-config python-dev python-virtualenv python3-pip python-pil libxml2-dev libxslt-dev unzip postgis osm2pgsql
 
 # if there's no planet, then download it
 if [[ ! -f "planet/${PLANET_FILE}" ]]; then

--- a/import/import_planet.sh
+++ b/import/import_planet.sh
@@ -69,7 +69,7 @@ trap stop_with_failure ERR
 echo "installing software" > $STATUS
 sudo DEBIAN_FRONTEND=noninteractive apt update
 sudo DEBIAN_FRONTEND=noninteractive apt upgrade -y -q
-sudo DEBIAN_FRONTEND=noninteractive apt install -y -q make g++ git awscli build-essential autoconf libtool pkg-config python-dev python-virtualenv python3-pip python-pil libxml2-dev libxslt-dev unzip postgis osm2pgsql
+sudo DEBIAN_FRONTEND=noninteractive apt install -y -q make g++ git awscli build-essential autoconf libtool pkg-config python-dev python3-pip python-pil libxml2-dev libxslt-dev unzip postgis osm2pgsql
 
 # if there's no planet, then download it
 if [[ ! -f "planet/${PLANET_FILE}" ]]; then

--- a/import/import_planet.sh
+++ b/import/import_planet.sh
@@ -69,14 +69,7 @@ trap stop_with_failure ERR
 echo "installing software" > $STATUS
 sudo DEBIAN_FRONTEND=noninteractive apt update
 sudo DEBIAN_FRONTEND=noninteractive apt upgrade -y -q
-sudo DEBIAN_FRONTEND=noninteractive apt install -y -q make g++ git awscli build-essential autoconf libtool pkg-config python-dev python-virtualenv python-pip python-pil libxml2-dev libxslt-dev unzip postgis
-
-# install osm2pgsql from PPA
-if [[ ! -x $OSM2PGSQL ]]; then
-    echo "installing osm2pgsql" > $STATUS
-    sudo DEBIAN_FRONTEND=noninteractive apt update
-    sudo DEBIAN_FRONTEND=noninteractive apt install -y -q osm2pgsql
-fi
+sudo DEBIAN_FRONTEND=noninteractive apt install -y -q make g++ git awscli build-essential autoconf libtool pkg-config python-dev python-virtualenv python-pip python-pil libxml2-dev libxslt-dev unzip postgis osm2pgsql
 
 # if there's no planet, then download it
 if [[ ! -f "planet/${PLANET_FILE}" ]]; then

--- a/import/osm2pgsql.py
+++ b/import/osm2pgsql.py
@@ -196,12 +196,13 @@ def start_osm2pgsql_instance(
         ec2, run_id, key_pair_name, security_group_id,
         iam_instance_profile, ip_addr):
     # find latest official ubuntu server image
+    #
     response = ec2.describe_images(
         Filters=[
             dict(Name='name', Values=[
-                'ubuntu/images/hvm-ssd/ubuntu-xenial-16.04-amd64-server-*',
+                'aws-parallelcluster-*-ubuntu-2004-lts-hvm-x86_64-*',
             ]),
-            dict(Name='owner-id', Values=['099720109477']),
+            dict(Name='owner-id', Values=['247102896272']),
         ],
     )
     latest_image = max(response['Images'], key=(lambda i: i['CreationDate']))


### PR DESCRIPTION
In order to use the newer, faster osm2pgsql, we either have to build locally or ugrade to new ubuntu.  The newer ubuntu does not ship with osm2pgsql so I have to install it, no need to check if it's already there.