### PR TITLE
install new version of pip during import_planet

### DIFF
--- a/import/import_planet.sh
+++ b/import/import_planet.sh
@@ -150,6 +150,7 @@ if [[ $ntuples -eq 0 ]]; then
 
     echo "installing vector-datasource dependencies" > $STATUS
     cd vector-datasource
+    pip install pip==19.0
     pip install -U -r requirements.txt
     python setup.py develop
 


### PR DESCRIPTION
The version of pip with this newer version of Ubuntu has some backwards compatibility issues.  Need to install an old one